### PR TITLE
Yelp gym updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 /config/master.key
 
 coverage/
-spec/fixtures/vcr_cassettes
 
 # Ignore application configuration
 /config/application.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
 before_install:
 - yes | gem update --system --force
 - gem install bundler
+env:
+  global:
+    secure: sHbQ5vg54DdGgwfb/cF67M4wtLq5VsOVRqudOpIcwllHsIgMCGVGJfPLtrv4bOYAW6P9oheB8zRPWFVGuu79WOqoUyOZ62fT+uRvkubKVDD4pLtxL03/lvaXJ+Ky5+I1BTsYlZXVRBgp+nDD5bWAiFrJgJ8dK1uim96SipqOjxKOonOGSPsKNvJA4W/QYJ8KAYsbHgiig/ekdmCERQcXsrB3KEqjC4I7tY/vu3YaSB7jhe1Rb0xhvCedQZNgQqngOxQoZ7U8YSacGLvzOwdFvc5WRyALJg2IJ8+FkOAtTKGZLEaso8Gv/k+yoA9OuAHU03/WSerznrLFBaN1KwO+iYOGlUQfof6gijirmclh0mvg6PTM9ZGObYt4jzM672pOD94ZKU/3MxJrniOigLuCjTTT3FTsrqwBMl6pSn1FMY5sEVyYaIBSP2Sofjoelcwj8BadqqKJUe8/ta8RGe+bh83l3Z0a1cJ8eCIKQ1w4bwzZrxpGSkxscrNsn4CXO8MQLWYNFgu1trpMrUxSr88do9yEohgdh5c+5pRkZTJqmTPZTQ6kfO5dr7mQpBu2WnPDsm/3ajTSqDcjmWLjhmZJrJHQKDDR7Aa4kwbyELaeIRU0Fb5tgsAxD8BukxAeIYpkkncMm3EOSb7zJjanO9TpyQZ8fvtiWMKvDaynC1WRcOM=
 script:
 - bundle exec rails db:{create,migrate} RAILS_ENV=test
 - bundle exec rspec -fd

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In addition to the base project requirements, some extra explorations and extens
 
 ## Database Schema
 
-![schema](https://user-images.githubusercontent.com/81220681/133701997-2e8a1242-d274-4bf2-af16-9f6c2a8a8480.png)
+![schema](https://user-images.githubusercontent.com/58891447/133915612-26cef18e-d9a0-488f-a05f-d2f842ed3d67.png)
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ The following table presents each API endpoint and its associated documentation
 Endpoint | Docs | Example
 ---------|------|--------
 **Users** | [docs](/docs/users.md)
-Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1)
+Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21)
 Create New User | [docs](/docs/users.md#create-new-user) |
 Update Existing User | [docs](/docs/users.md#update-existing-user) |
-Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/gyms)
-Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/friendships)
+Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms)
+Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/friendships)
 Add Friend | *pending* |
 Remove Friend | *pending* |
 **Events** | [docs](/docs/events.md)
-Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/events)
+Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/events)
 Get User New Event | *pending* | *pending*
 Create User New Event | [docs](/docs/events#create-new-event.md) |
 **Gyms** | [docs](/docs/gyms.md)
 Get Gyms Near User | *pending* | *pending*
-Get Gym Show Page | [docs](/docs/gyms#get-gym.md) | [example](https://spotme-app-api.herokuapp.com/api/v1/gyms/1)
+Get Gym Show Page | [docs](/docs/gyms#get-gym.md) | [example](https://spotme-app-api.herokuapp.com/api/v1/gyms/11)
 Add Gym Member | [docs](/docs/gyms#create-new-gym-member.md) |
 Remove Gym Member | [docs](/docs/gyms#remove-existing-gym-member.md) |
 

--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ The following table presents each API endpoint and its associated documentation
 Endpoint | Docs | Example
 ---------|------|--------
 **Users** | [docs](/docs/users.md)
-Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21)
+Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31)
 Create New User | [docs](/docs/users.md#create-new-user) |
 Update Existing User | [docs](/docs/users.md#update-existing-user) |
-Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms)
-Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/friendships)
+Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms)
+Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/friendships)
 Add Friend | *pending* |
 Remove Friend | *pending* |
 **Events** | [docs](/docs/events.md)
-Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/21/events)
+Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/events)
 Get User New Event | *pending* | *pending*
 Create User New Event | [docs](/docs/events#create-new-event.md) |
 **Gyms** | [docs](/docs/gyms.md)
 Get Gyms Near User | *pending* | *pending*
-Get Gym Show Page | [docs](/docs/gyms#get-gym.md) | [example](https://spotme-app-api.herokuapp.com/api/v1/gyms/11)
+Get Gym Show Page | [docs](/docs/gyms#get-gym.md) | [example](https://spotme-app-api.herokuapp.com/api/v1/gyms/16)
 Add Gym Member | [docs](/docs/gyms#create-new-gym-member.md) |
 Remove Gym Member | [docs](/docs/gyms#remove-existing-gym-member.md) |
 

--- a/app/controllers/api/v1/users/events_controller.rb
+++ b/app/controllers/api/v1/users/events_controller.rb
@@ -3,7 +3,9 @@
 class Api::V1::Users::EventsController < ApplicationController
   def index
     user = User.find(params[:user_id])
-    events = user.events
+    # TODO: add flexibility based on query params to retrieve upcoming vs past events
+    # (i.e. if we decide to add activity log to dashboard)
+    events = user.upcoming_events
 
     render json: EventSerializer.new(events).serializable_hash, status: :ok
   end

--- a/app/facades/gym_search_facade.rb
+++ b/app/facades/gym_search_facade.rb
@@ -1,11 +1,8 @@
 class GymSearchFacade
-  def self.query_yelp(location)
-    gyms = YelpService.gyms_near_user(location)
-
-    if gyms[:businesses]
-      gyms[:businesses].map do |gym|
-        GymFromSearch.new(gym)
-      end
+  class << self
+    def query_yelp(location)
+      gyms = YelpService.get_gyms(location)
+      gyms[:businesses].map { |gym| GymFromSearch.new(gym) } if gyms[:businesses]
     end
   end
 end

--- a/app/models/gym.rb
+++ b/app/models/gym.rb
@@ -4,4 +4,5 @@ class Gym < ApplicationRecord
   has_many :users, through: :gym_members
 
   validates :yelp_gym_id, presence: true
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,4 +21,8 @@ class User < ApplicationRecord
   validates :availability_afternoon, inclusion: { in: [true, false] }
   validates :availability_evening, inclusion: { in: [true, false] }
   validates :full_name, presence: true
+
+  def upcoming_events
+    events.where('date_time >= ?', Time.zone.now)
+  end
 end

--- a/app/poros/gym_from_search.rb
+++ b/app/poros/gym_from_search.rb
@@ -5,7 +5,7 @@ class GymFromSearch
     @id = nil
     @name = info[:name]
     @yelp_gym_id = info[:id]
-    @address = info[:location][:display_address].join(", ")
+    @address = info[:location][:display_address].join(', ')
     @phone = info[:display_phone]
   end
 end

--- a/app/serializers/gym_serializer.rb
+++ b/app/serializers/gym_serializer.rb
@@ -1,5 +1,5 @@
 class GymSerializer
   include JSONAPI::Serializer
 
-  attributes :yelp_gym_id
+  attributes :yelp_gym_id, :name
 end

--- a/app/services/yelp_service.rb
+++ b/app/services/yelp_service.rb
@@ -1,12 +1,20 @@
 class YelpService
-  def self.connection_setup
-    Faraday.new(url: 'https://api.yelp.com/') do |faraday|
-      faraday.headers['Authorization'] = ENV['yelp_api_key']
+  class << self
+    def conn
+      Faraday.new(url: 'https://api.yelp.com/') do |faraday|
+        faraday.headers['Authorization'] = ENV['yelp_api_key']
+      end
     end
-  end
 
-  def self.gyms_near_user(location)
-    response = connection_setup.get("v3/businesses/search?term=gyms&radius=40000&sort_by=distance&location=#{location}")
-    JSON.parse(response.body, symbolize_names: true)
+    def params
+      'term=gyms&radius=40000&sort_by=distance'
+    end
+
+    def get_gyms(location)
+      JSON.parse(
+        conn.get("v3/businesses/search?#{params}&location=#{location}").body,
+        symbolize_names: true
+      )
+    end
   end
 end

--- a/db/migrate/20210919042302_add_name_to_gyms.rb
+++ b/db/migrate/20210919042302_add_name_to_gyms.rb
@@ -1,0 +1,5 @@
+class AddNameToGyms < ActiveRecord::Migration[5.2]
+  def change
+    add_column :gyms, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_17_220251) do
+ActiveRecord::Schema.define(version: 2021_09_19_042302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_220251) do
     t.string "yelp_gym_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/docs/events.md
+++ b/docs/events.md
@@ -26,7 +26,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/1/events
+GET https://spotme-app-api.herokuapp.com/api/v1/users/21/events
 ```
 
 ### Example Response (Successful)
@@ -110,7 +110,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/1/gyms/1/events
+POST https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11/events
 ```
 
 ### Example Response (Successful)

--- a/docs/events.md
+++ b/docs/events.md
@@ -26,7 +26,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/21/events
+GET https://spotme-app-api.herokuapp.com/api/v1/users/31/events
 ```
 
 ### Example Response (Successful)
@@ -110,7 +110,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11/events
+POST https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16/events
 ```
 
 ### Example Response (Successful)

--- a/docs/gyms.md
+++ b/docs/gyms.md
@@ -22,7 +22,6 @@ GET /gyms/{gym_id}
 Name       | Data Type    | In    | Required/Optional | Description
 -----------|--------------|-------|-------------------|------------
 `gym_id` | Integer | Path | Required | The ID of the gym.
-<!-- sample gym yelp_id: dYewYWV40roEGF9SzAHI5Q -->
 
 ### Example Request
 
@@ -40,7 +39,9 @@ Status: 200 OK
 {:data=>
   {:id=>"1654",
    :type=>"gym",
-   :attributes=>{:yelp_gym_id=>"preb6u3g2bot2u0ouivy02"}}
+   :attributes=>{
+    :yelp_gym_id=>"preb6u3g2bot2u0ouivy02"
+    :name=>"Planet Fitness"}}
 }
 ```
 

--- a/docs/gyms.md
+++ b/docs/gyms.md
@@ -26,7 +26,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/gyms/11
+GET https://spotme-app-api.herokuapp.com/api/v1/gyms/16
 ```
 
 ### Example Response (Successful)
@@ -79,7 +79,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11/gym_members
+POST https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16/gym_members
 ```
 
 ### Example Response (Successful)
@@ -142,7 +142,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-DELETE https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11
+DELETE https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16
 ```
 
 ### Example Response (No Content)

--- a/docs/gyms.md
+++ b/docs/gyms.md
@@ -26,7 +26,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/gyms/1
+GET https://spotme-app-api.herokuapp.com/api/v1/gyms/11
 ```
 
 ### Example Response (Successful)
@@ -79,7 +79,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/1/gyms/1/gym_members
+POST https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11/gym_members
 ```
 
 ### Example Response (Successful)
@@ -142,7 +142,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-DELETE https://spotme-app-api.herokuapp.com/api/v1/users/1/gyms/1
+DELETE https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms/11
 ```
 
 ### Example Response (No Content)

--- a/docs/users.md
+++ b/docs/users.md
@@ -28,7 +28,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/1
+GET https://spotme-app-api.herokuapp.com/api/v1/users/21
 ```
 
 ### Example Response (Successful)
@@ -175,7 +175,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-PATCH https://spotme-app-api.herokuapp.com/api/v1/users/1
+PATCH https://spotme-app-api.herokuapp.com/api/v1/users/21
 ```
 
 ### Example Response (Successful)
@@ -239,7 +239,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/1/gyms
+GET https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms
 ```
 
 ### Example Response (Successful)
@@ -302,7 +302,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/1/friendships
+GET https://spotme-app-api.herokuapp.com/api/v1/users/21/friendships
 ```
 
 ### Example Response (Successful)

--- a/docs/users.md
+++ b/docs/users.md
@@ -28,7 +28,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/21
+GET https://spotme-app-api.herokuapp.com/api/v1/users/31
 ```
 
 ### Example Response (Successful)
@@ -175,7 +175,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-PATCH https://spotme-app-api.herokuapp.com/api/v1/users/21
+PATCH https://spotme-app-api.herokuapp.com/api/v1/users/31
 ```
 
 ### Example Response (Successful)
@@ -239,7 +239,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/21/gyms
+GET https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms
 ```
 
 ### Example Response (Successful)
@@ -302,7 +302,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/21/friendships
+GET https://spotme-app-api.herokuapp.com/api/v1/users/31/friendships
 ```
 
 ### Example Response (Successful)

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :event do
-    date_time { DateTime.now + rand(10).days }
+    date_time { DateTime.now + rand(1..10).days }
     activity { Faker::Hobby.activity }
     user
     gym

--- a/spec/factories/gyms.rb
+++ b/spec/factories/gyms.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :gym do
     yelp_gym_id { Faker::Alphanumeric.alphanumeric(number: 22) }
+    name { Faker::Company.name }
   end
 end

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=89405&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 84320d337ca80d3b
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-nbbdt; site=public_api_v3
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4981'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-64-74-uswest2aprod
+      X-Extlb:
+      - 10-69-64-74-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:36 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8274-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
+        "latitude": 40.4462157989704}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:36 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=89405&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-95qdr; site=public_api_v3
+      X-Zipkin-Id:
+      - da1675970c0373ef
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4980'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-98-90-uswest2aprod
+      X-Extlb:
+      - 10-69-98-90-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:37 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8254-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
+        "latitude": 40.4462157989704}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:37 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -1,0 +1,523 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=34145&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4985'
+      X-Zipkin-Id:
+      - e7eb11697f20fa17
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-d692g; site=public_api_v3
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-87-203-uswest2aprod
+      X-Extlb:
+      - 10-69-87-203-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:32 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8252-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "dYewYWV40roEGF9SzAHI5Q", "alias": "ambitions-wellness-and-body-coaching-marco-island",
+        "name": "Ambitions Wellness and Body Coaching", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/FOiNcgNgOtrz_54DrhFWzA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ambitions-wellness-and-body-coaching-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "yoga", "title": "Yoga"}, {"alias": "nutritionists", "title": "Nutritionists"}],
+        "rating": 5.0, "coordinates": {"latitude": 25.933615, "longitude": -81.698522},
+        "transactions": [], "location": {"address1": "1817 San Marco Rd", "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
+        FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
+        2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 4.0, "coordinates": {"latitude": 25.9341526, "longitude": -81.6989467},
+        "transactions": [], "price": "$$$", "location": {"address1": "1817 San Marco
+        Rd", "address2": null, "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["1817 San Marco
+        Rd", "Marco Island, FL 34145"]}, "phone": "+12393949235", "display_phone":
+        "(239) 394-9235", "distance": 2580.2116310113224}, {"id": "HxK5-XEhjl0x0RR9PAgBVQ",
+        "alias": "ymca-of-south-collier-marco-ymca-marco-island", "name": "YMCA of
+        South Collier-Marco YMCA", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/f3IWcztQgl8-9j1z8BsLdg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ymca-of-south-collier-marco-ymca-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}, {"alias": "healthtrainers",
+        "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude": 25.93536,
+        "longitude": -81.70816}, "transactions": [], "location": {"address1": "101
+        Sand Hill St", "address2": "", "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["101 Sand Hill
+        St", "Marco Island, FL 34145"]}, "phone": "+12393949622", "display_phone":
+        "(239) 394-9622", "distance": 3006.3576771165713}, {"id": "77ZmLGWFlgXoGie_p22wvQ",
+        "alias": "tender-touch-massage-marco-island", "name": "Tender Touch Massage",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/tender-touch-massage-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage_therapy", "title": "Massage Therapy"}, {"alias": "physicaltherapy",
+        "title": "Physical Therapy"}], "rating": 5.0, "coordinates": {"latitude":
+        25.9206, "longitude": -81.72583}, "transactions": [], "location": {"address1":
+        "651 S Collier Blvd", "address2": "", "address3": "", "city": "Marco Island",
+        "zip_code": "34145", "country": "US", "state": "FL", "display_address": ["651
+        S Collier Blvd", "Marco Island, FL 34145"]}, "phone": "+12393896999", "display_phone":
+        "(239) 389-6999", "distance": 3085.063199321182}, {"id": "5ri7jEdMHytwaNpuz89Veg",
+        "alias": "puresoul-personal-training-marco-island", "name": "PureSoul Personal
+        Training", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/U_8a5NOR7H5vwcPQ5TVVLg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/puresoul-personal-training-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "nutritionists", "title": "Nutritionists"}, {"alias": "yoga", "title":
+        "Yoga"}], "rating": 5.0, "coordinates": {"latitude": 25.93563, "longitude":
+        -81.71219}, "transactions": [], "location": {"address1": null, "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["Marco Island, FL 34145"]}, "phone":
+        "+14014407345", "display_phone": "(401) 440-7345", "distance": 3419.511245856647},
+        {"id": "uiOijFqy7BxDfOa2SlEGkQ", "alias": "revival-yoga-fitness-studio-marco-island",
+        "name": "Revival Yoga Fitness Studio", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/sPbtQogiYGyyL_sFzgDurQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/revival-yoga-fitness-studio-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "pilates", "title": "Pilates"}], "rating": 4.5, "coordinates": {"latitude":
+        25.9543380737305, "longitude": -81.7285919189453}, "transactions": [], "location":
+        {"address1": "760 N Collier Blvd", "address2": "Ste 107", "address3": "",
+        "city": "Marco Island", "zip_code": "34145", "country": "US", "state": "FL",
+        "display_address": ["760 N Collier Blvd", "Ste 107", "Marco Island, FL 34145"]},
+        "phone": "+12393933400", "display_phone": "(239) 393-3400", "distance": 5780.626421179173},
+        {"id": "tk8UhlNErqTmL65pdkGR1g", "alias": "marco-fitness-club-marco-island",
+        "name": "Marco Fitness Club", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/marco-fitness-club-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "healthtrainers", "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude":
+        25.959680557251, "longitude": -81.7245101928711}, "transactions": [], "location":
+        {"address1": "871 E Elkcam Cir", "address2": "", "address3": "", "city": "Marco
+        Island", "zip_code": "34145", "country": "US", "state": "FL", "display_address":
+        ["871 E Elkcam Cir", "Marco Island, FL 34145"]}, "phone": "+12393943705",
+        "display_phone": "(239) 394-3705", "distance": 6126.426255565895}, {"id":
+        "xWJzfnHx8aEvi7l1Qcc19A", "alias": "1on1getfit-naples-2", "name": "1on1getfit",
+        "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CodR3jx8_45MItEASwNxpw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/1on1getfit-naples-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "healthtrainers", "title": "Trainers"}, {"alias": "weightlosscenters",
+        "title": "Weight Loss Centers"}], "rating": 5.0, "coordinates": {"latitude":
+        26.04595939009, "longitude": -81.6995589367082}, "transactions": [], "location":
+        {"address1": "6060 Collier Blvd", "address2": "", "address3": "", "city":
+        "Naples", "zip_code": "34114", "country": "US", "state": "FL", "display_address":
+        ["6060 Collier Blvd", "Naples, FL 34114"]}, "phone": "+12392937361", "display_phone":
+        "(239) 293-7361", "distance": 15068.754782760383}, {"id": "IZO8EwsTMxP6rLh-vvIkEg",
+        "alias": "hardcore-gym-naples", "name": "Hardcore Gym", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/1xIv8JLSpP8nPbF3upLB1w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/hardcore-gym-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 12, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.074733, "longitude": -81.7180927}, "transactions":
+        [], "location": {"address1": "11524 Tamiami Trl E", "address2": null, "address3":
+        "", "city": "Naples", "zip_code": "34113", "country": "US", "state": "FL",
+        "display_address": ["11524 Tamiami Trl E", "Naples, FL 34113"]}, "phone":
+        "+12397932639", "display_phone": "(239) 793-2639", "distance": 18386.506018478212},
+        {"id": "Gq1bUOCQXr7k83ZehwUVHA", "alias": "zumba-with-casta-naples", "name":
+        "Zumba With Casta", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/dOSEGQD82fwAdGClbcAb_A/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/zumba-with-casta-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.109026, "longitude": -81.76371},
+        "transactions": [], "location": {"address1": "3500 Thomasson Dr", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["3500 Thomasson Dr", "Naples, FL 34112"]},
+        "phone": "+12394652043", "display_phone": "(239) 465-2043", "distance": 22775.1597933018},
+        {"id": "t7kOb1q4uCY1trbrD7EdHw", "alias": "arts-and-hot-yoga-naples", "name":
+        "Arts & Hot Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Y5P_MAnOdQx5_a9WRwdz3g/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/arts-and-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 5.0, "coordinates": {"latitude": 26.11565,
+        "longitude": -81.75704}, "transactions": [], "location": {"address1": "4270
+        Tamiami Trl E", "address2": "Ste 16", "address3": "", "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["4270 Tamiami
+        Trl E", "Ste 16", "Naples, FL 34112"]}, "phone": "+12393001066", "display_phone":
+        "(239) 300-1066", "distance": 23530.63554890676}, {"id": "Ph-l7AABs7Bu1bCUFpalFA",
+        "alias": "the-sweet-science-boxing-naples", "name": "The Sweet Science Boxing",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/the-sweet-science-boxing-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "boxing", "title": "Boxing"}, {"alias": "gyms", "title": "Gyms"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.11565, "longitude": -81.75704},
+        "transactions": [], "location": {"address1": "4270 Tamiami Trl E", "address2":
+        "Ste 13", "address3": null, "city": "Naples", "zip_code": "34112", "country":
+        "US", "state": "FL", "display_address": ["4270 Tamiami Trl E", "Ste 13", "Naples,
+        FL 34112"]}, "phone": "+12397778732", "display_phone": "(239) 777-8732", "distance":
+        23589.542323878202}, {"id": "p3TYsD-nQ_H4H3qJINeF7w", "alias": "modern-steps-school-of-dance-naples",
+        "name": "Modern Steps School Of Dance", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/1D2QDCTc3Vj4I0MRMXjH5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/modern-steps-school-of-dance-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "theater", "title": "Performing
+        Arts"}, {"alias": "dancestudio", "title": "Dance Studios"}], "rating": 5.0,
+        "coordinates": {"latitude": 26.1168370216529, "longitude": -81.7553837189102},
+        "transactions": [], "location": {"address1": "4117 Tamiami Trl E", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["4117 Tamiami Trl E", "Naples, FL 34112"]},
+        "phone": "+12397753445", "display_phone": "(239) 775-3445", "distance": 23675.95011343892},
+        {"id": "ycYJSNH4cpkkHKj3ZlwTQQ", "alias": "pure-fitness-naples", "name": "Pure
+        Fitness", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/pure-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.11957, "longitude": -81.75707}, "transactions":
+        [], "location": {"address1": "3831 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["3831 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12397937475",
+        "display_phone": "(239) 793-7475", "distance": 24009.201538904643}, {"id":
+        "-aD2laK768E7SRIU8PW6gg", "alias": "drip-hot-yoga-naples", "name": "Drip Hot
+        Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/drip-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage", "title": "Massage"}], "rating": 5.0, "coordinates": {"latitude":
+        26.123462, "longitude": -81.770781}, "transactions": [], "location": {"address1":
+        "3212 Bayshore Dr", "address2": "", "address3": null, "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["3212 Bayshore
+        Dr", "Naples, FL 34112"]}, "phone": "+17274920096", "display_phone": "(727)
+        492-0096", "distance": 24803.13998889454}, {"id": "3rXE3wNkZCLQ0LdCmvq9oQ",
+        "alias": "trijake-fitness-naples", "name": "TriJake Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/XX7wqkahe16UVA2lKEYkSQ/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/trijake-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1281399, "longitude": -81.76079},
+        "transactions": [], "location": {"address1": "200 Palm Drive 43-3", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["200 Palm Drive 43-3", "Naples, FL 34112"]},
+        "phone": "", "display_phone": "", "distance": 25028.1569712333}, {"id": "V_cyxLoEfzDsixGPAtC6zw",
+        "alias": "planet-fitness-naples-3", "name": "Planet Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/Zf92fHClYDIoyb3pP6951g/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/planet-fitness-naples-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 20, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        3.0, "coordinates": {"latitude": 26.129761, "longitude": -81.772522}, "transactions":
+        [], "location": {"address1": "2650 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["2650 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12395449171",
+        "display_phone": "(239) 544-9171", "distance": 25523.59941699116}, {"id":
+        "MTphZhcEeHTGUCkwpM7tow", "alias": "tri-tone-triple-barre-fitness-naples",
+        "name": "Tri Tone Triple Barre Fitness", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/SrrmAki7_MiVglr5R1gfWQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/tri-tone-triple-barre-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "barreclasses", "title": "Barre
+        Classes"}], "rating": 5.0, "coordinates": {"latitude": 26.13678, "longitude":
+        -81.78163}, "transactions": [], "location": {"address1": "1800 Tamiami Trl
+        E", "address2": "", "address3": null, "city": "Naples", "zip_code": "34112",
+        "country": "US", "state": "FL", "display_address": ["1800 Tamiami Trl E",
+        "Naples, FL 34112"]}, "phone": "+12394041034", "display_phone": "(239) 404-1034",
+        "distance": 26556.36780934057}, {"id": "6_NmdY946RBKA9LYTr6l7A", "alias":
+        "infant-swimming-resource-naples-naples", "name": "Infant Swimming Resource
+        Naples", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/ow82YqVJ6h08bTPRPKeUJQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/infant-swimming-resource-naples-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "swimminglessons", "title": "Swimming
+        Lessons/Schools"}, {"alias": "swimmingpools", "title": "Swimming Pools"}],
+        "rating": 3.0, "coordinates": {"latitude": 26.138722, "longitude": -81.780302},
+        "transactions": [], "location": {"address1": "1949 Davis Blvd", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34104", "country": "US",
+        "state": "FL", "display_address": ["1949 Davis Blvd", "Naples, FL 34104"]},
+        "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896},
+        {"id": "xnuYs-1f9OlfRunVZHIlEA", "alias": "american-sports-karate-naples",
+        "name": "American Sports Karate", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/pI7kIqeZzULYmBN_DudMIA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/american-sports-karate-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "karate", "title": "Karate"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1505054, "longitude": -81.690138},
+        "transactions": [], "location": {"address1": "9950 Business Cir", "address2":
+        null, "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["9950 Business Cir", "Naples, FL 34112"]},
+        "phone": "+12396432275", "display_phone": "(239) 643-2275", "distance": 26700.711523141435}],
+        "total": 115, "region": {"center": {"longitude": -81.69708251953125, "latitude":
+        25.91046095897436}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:32 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=34145&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-95qdr; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - 78067a19939e6f15
+      Ratelimit-Remaining:
+      - '4984'
+      Server:
+      - envoy
+      X-Proxied:
+      - 10-69-152-99-uswest2bprod
+      X-Extlb:
+      - 10-69-152-99-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:33 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8254-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "dYewYWV40roEGF9SzAHI5Q", "alias": "ambitions-wellness-and-body-coaching-marco-island",
+        "name": "Ambitions Wellness and Body Coaching", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/FOiNcgNgOtrz_54DrhFWzA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ambitions-wellness-and-body-coaching-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "yoga", "title": "Yoga"}, {"alias": "nutritionists", "title": "Nutritionists"}],
+        "rating": 5.0, "coordinates": {"latitude": 25.933615, "longitude": -81.698522},
+        "transactions": [], "location": {"address1": "1817 San Marco Rd", "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
+        FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
+        2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 4.0, "coordinates": {"latitude": 25.9341526, "longitude": -81.6989467},
+        "transactions": [], "price": "$$$", "location": {"address1": "1817 San Marco
+        Rd", "address2": null, "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["1817 San Marco
+        Rd", "Marco Island, FL 34145"]}, "phone": "+12393949235", "display_phone":
+        "(239) 394-9235", "distance": 2580.2116310113224}, {"id": "HxK5-XEhjl0x0RR9PAgBVQ",
+        "alias": "ymca-of-south-collier-marco-ymca-marco-island", "name": "YMCA of
+        South Collier-Marco YMCA", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/f3IWcztQgl8-9j1z8BsLdg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ymca-of-south-collier-marco-ymca-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}, {"alias": "healthtrainers",
+        "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude": 25.93536,
+        "longitude": -81.70816}, "transactions": [], "location": {"address1": "101
+        Sand Hill St", "address2": "", "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["101 Sand Hill
+        St", "Marco Island, FL 34145"]}, "phone": "+12393949622", "display_phone":
+        "(239) 394-9622", "distance": 3006.3576771165713}, {"id": "77ZmLGWFlgXoGie_p22wvQ",
+        "alias": "tender-touch-massage-marco-island", "name": "Tender Touch Massage",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/tender-touch-massage-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage_therapy", "title": "Massage Therapy"}, {"alias": "physicaltherapy",
+        "title": "Physical Therapy"}], "rating": 5.0, "coordinates": {"latitude":
+        25.9206, "longitude": -81.72583}, "transactions": [], "location": {"address1":
+        "651 S Collier Blvd", "address2": "", "address3": "", "city": "Marco Island",
+        "zip_code": "34145", "country": "US", "state": "FL", "display_address": ["651
+        S Collier Blvd", "Marco Island, FL 34145"]}, "phone": "+12393896999", "display_phone":
+        "(239) 389-6999", "distance": 3085.063199321182}, {"id": "5ri7jEdMHytwaNpuz89Veg",
+        "alias": "puresoul-personal-training-marco-island", "name": "PureSoul Personal
+        Training", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/U_8a5NOR7H5vwcPQ5TVVLg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/puresoul-personal-training-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "nutritionists", "title": "Nutritionists"}, {"alias": "yoga", "title":
+        "Yoga"}], "rating": 5.0, "coordinates": {"latitude": 25.93563, "longitude":
+        -81.71219}, "transactions": [], "location": {"address1": null, "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["Marco Island, FL 34145"]}, "phone":
+        "+14014407345", "display_phone": "(401) 440-7345", "distance": 3419.511245856647},
+        {"id": "uiOijFqy7BxDfOa2SlEGkQ", "alias": "revival-yoga-fitness-studio-marco-island",
+        "name": "Revival Yoga Fitness Studio", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/sPbtQogiYGyyL_sFzgDurQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/revival-yoga-fitness-studio-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "pilates", "title": "Pilates"}], "rating": 4.5, "coordinates": {"latitude":
+        25.9543380737305, "longitude": -81.7285919189453}, "transactions": [], "location":
+        {"address1": "760 N Collier Blvd", "address2": "Ste 107", "address3": "",
+        "city": "Marco Island", "zip_code": "34145", "country": "US", "state": "FL",
+        "display_address": ["760 N Collier Blvd", "Ste 107", "Marco Island, FL 34145"]},
+        "phone": "+12393933400", "display_phone": "(239) 393-3400", "distance": 5780.626421179173},
+        {"id": "tk8UhlNErqTmL65pdkGR1g", "alias": "marco-fitness-club-marco-island",
+        "name": "Marco Fitness Club", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/marco-fitness-club-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "healthtrainers", "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude":
+        25.959680557251, "longitude": -81.7245101928711}, "transactions": [], "location":
+        {"address1": "871 E Elkcam Cir", "address2": "", "address3": "", "city": "Marco
+        Island", "zip_code": "34145", "country": "US", "state": "FL", "display_address":
+        ["871 E Elkcam Cir", "Marco Island, FL 34145"]}, "phone": "+12393943705",
+        "display_phone": "(239) 394-3705", "distance": 6126.426255565895}, {"id":
+        "xWJzfnHx8aEvi7l1Qcc19A", "alias": "1on1getfit-naples-2", "name": "1on1getfit",
+        "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CodR3jx8_45MItEASwNxpw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/1on1getfit-naples-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "healthtrainers", "title": "Trainers"}, {"alias": "weightlosscenters",
+        "title": "Weight Loss Centers"}], "rating": 5.0, "coordinates": {"latitude":
+        26.04595939009, "longitude": -81.6995589367082}, "transactions": [], "location":
+        {"address1": "6060 Collier Blvd", "address2": "", "address3": "", "city":
+        "Naples", "zip_code": "34114", "country": "US", "state": "FL", "display_address":
+        ["6060 Collier Blvd", "Naples, FL 34114"]}, "phone": "+12392937361", "display_phone":
+        "(239) 293-7361", "distance": 15068.754782760383}, {"id": "IZO8EwsTMxP6rLh-vvIkEg",
+        "alias": "hardcore-gym-naples", "name": "Hardcore Gym", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/1xIv8JLSpP8nPbF3upLB1w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/hardcore-gym-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 12, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.074733, "longitude": -81.7180927}, "transactions":
+        [], "location": {"address1": "11524 Tamiami Trl E", "address2": null, "address3":
+        "", "city": "Naples", "zip_code": "34113", "country": "US", "state": "FL",
+        "display_address": ["11524 Tamiami Trl E", "Naples, FL 34113"]}, "phone":
+        "+12397932639", "display_phone": "(239) 793-2639", "distance": 18386.506018478212},
+        {"id": "Gq1bUOCQXr7k83ZehwUVHA", "alias": "zumba-with-casta-naples", "name":
+        "Zumba With Casta", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/dOSEGQD82fwAdGClbcAb_A/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/zumba-with-casta-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.109026, "longitude": -81.76371},
+        "transactions": [], "location": {"address1": "3500 Thomasson Dr", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["3500 Thomasson Dr", "Naples, FL 34112"]},
+        "phone": "+12394652043", "display_phone": "(239) 465-2043", "distance": 22775.1597933018},
+        {"id": "t7kOb1q4uCY1trbrD7EdHw", "alias": "arts-and-hot-yoga-naples", "name":
+        "Arts & Hot Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Y5P_MAnOdQx5_a9WRwdz3g/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/arts-and-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 5.0, "coordinates": {"latitude": 26.11565,
+        "longitude": -81.75704}, "transactions": [], "location": {"address1": "4270
+        Tamiami Trl E", "address2": "Ste 16", "address3": "", "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["4270 Tamiami
+        Trl E", "Ste 16", "Naples, FL 34112"]}, "phone": "+12393001066", "display_phone":
+        "(239) 300-1066", "distance": 23530.63554890676}, {"id": "Ph-l7AABs7Bu1bCUFpalFA",
+        "alias": "the-sweet-science-boxing-naples", "name": "The Sweet Science Boxing",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/the-sweet-science-boxing-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "boxing", "title": "Boxing"}, {"alias": "gyms", "title": "Gyms"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.11565, "longitude": -81.75704},
+        "transactions": [], "location": {"address1": "4270 Tamiami Trl E", "address2":
+        "Ste 13", "address3": null, "city": "Naples", "zip_code": "34112", "country":
+        "US", "state": "FL", "display_address": ["4270 Tamiami Trl E", "Ste 13", "Naples,
+        FL 34112"]}, "phone": "+12397778732", "display_phone": "(239) 777-8732", "distance":
+        23589.542323878202}, {"id": "p3TYsD-nQ_H4H3qJINeF7w", "alias": "modern-steps-school-of-dance-naples",
+        "name": "Modern Steps School Of Dance", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/1D2QDCTc3Vj4I0MRMXjH5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/modern-steps-school-of-dance-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "theater", "title": "Performing
+        Arts"}, {"alias": "dancestudio", "title": "Dance Studios"}], "rating": 5.0,
+        "coordinates": {"latitude": 26.1168370216529, "longitude": -81.7553837189102},
+        "transactions": [], "location": {"address1": "4117 Tamiami Trl E", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["4117 Tamiami Trl E", "Naples, FL 34112"]},
+        "phone": "+12397753445", "display_phone": "(239) 775-3445", "distance": 23675.95011343892},
+        {"id": "ycYJSNH4cpkkHKj3ZlwTQQ", "alias": "pure-fitness-naples", "name": "Pure
+        Fitness", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/pure-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.11957, "longitude": -81.75707}, "transactions":
+        [], "location": {"address1": "3831 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["3831 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12397937475",
+        "display_phone": "(239) 793-7475", "distance": 24009.201538904643}, {"id":
+        "-aD2laK768E7SRIU8PW6gg", "alias": "drip-hot-yoga-naples", "name": "Drip Hot
+        Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/drip-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage", "title": "Massage"}], "rating": 5.0, "coordinates": {"latitude":
+        26.123462, "longitude": -81.770781}, "transactions": [], "location": {"address1":
+        "3212 Bayshore Dr", "address2": "", "address3": null, "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["3212 Bayshore
+        Dr", "Naples, FL 34112"]}, "phone": "+17274920096", "display_phone": "(727)
+        492-0096", "distance": 24803.13998889454}, {"id": "3rXE3wNkZCLQ0LdCmvq9oQ",
+        "alias": "trijake-fitness-naples", "name": "TriJake Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/XX7wqkahe16UVA2lKEYkSQ/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/trijake-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1281399, "longitude": -81.76079},
+        "transactions": [], "location": {"address1": "200 Palm Drive 43-3", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["200 Palm Drive 43-3", "Naples, FL 34112"]},
+        "phone": "", "display_phone": "", "distance": 25028.1569712333}, {"id": "V_cyxLoEfzDsixGPAtC6zw",
+        "alias": "planet-fitness-naples-3", "name": "Planet Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/Zf92fHClYDIoyb3pP6951g/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/planet-fitness-naples-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 20, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        3.0, "coordinates": {"latitude": 26.129761, "longitude": -81.772522}, "transactions":
+        [], "location": {"address1": "2650 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["2650 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12395449171",
+        "display_phone": "(239) 544-9171", "distance": 25523.59941699116}, {"id":
+        "MTphZhcEeHTGUCkwpM7tow", "alias": "tri-tone-triple-barre-fitness-naples",
+        "name": "Tri Tone Triple Barre Fitness", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/SrrmAki7_MiVglr5R1gfWQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/tri-tone-triple-barre-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "barreclasses", "title": "Barre
+        Classes"}], "rating": 5.0, "coordinates": {"latitude": 26.13678, "longitude":
+        -81.78163}, "transactions": [], "location": {"address1": "1800 Tamiami Trl
+        E", "address2": "", "address3": null, "city": "Naples", "zip_code": "34112",
+        "country": "US", "state": "FL", "display_address": ["1800 Tamiami Trl E",
+        "Naples, FL 34112"]}, "phone": "+12394041034", "display_phone": "(239) 404-1034",
+        "distance": 26556.36780934057}, {"id": "6_NmdY946RBKA9LYTr6l7A", "alias":
+        "infant-swimming-resource-naples-naples", "name": "Infant Swimming Resource
+        Naples", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/ow82YqVJ6h08bTPRPKeUJQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/infant-swimming-resource-naples-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "swimminglessons", "title": "Swimming
+        Lessons/Schools"}, {"alias": "swimmingpools", "title": "Swimming Pools"}],
+        "rating": 3.0, "coordinates": {"latitude": 26.138722, "longitude": -81.780302},
+        "transactions": [], "location": {"address1": "1949 Davis Blvd", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34104", "country": "US",
+        "state": "FL", "display_address": ["1949 Davis Blvd", "Naples, FL 34104"]},
+        "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896},
+        {"id": "xnuYs-1f9OlfRunVZHIlEA", "alias": "american-sports-karate-naples",
+        "name": "American Sports Karate", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/pI7kIqeZzULYmBN_DudMIA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/american-sports-karate-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "karate", "title": "Karate"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1505054, "longitude": -81.690138},
+        "transactions": [], "location": {"address1": "9950 Business Cir", "address2":
+        null, "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["9950 Business Cir", "Naples, FL 34112"]},
+        "phone": "+12396432275", "display_phone": "(239) 643-2275", "distance": 26700.711523141435}],
+        "total": 115, "region": {"center": {"longitude": -81.69708251953125, "latitude":
+        25.91046095897436}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -1,0 +1,437 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=04572&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Remaining:
+      - '4983'
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-dd49q; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 8667d3f00d2a0a11
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-189-127-uswest2bprod
+      X-Extlb:
+      - 10-69-189-127-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:35 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8243-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "RI8Gd94NEgZMuPJLCCXc5A", "alias": "ocean-blue-fitness-damariscotta",
+        "name": "Ocean Blue Fitness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/Dpp_3Mn5OLs7IsOI5SqARg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ocean-blue-fitness-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "pilates", "title": "Pilates"},
+        {"alias": "healthtrainers", "title": "Trainers"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.03321, "longitude": -69.51981}, "transactions": [], "location":
+        {"address1": "64 Chapman St", "address2": "", "address3": null, "city": "Damariscotta",
+        "zip_code": "04543", "country": "US", "state": "ME", "display_address": ["64
+        Chapman St", "Damariscotta, ME 04543"]}, "phone": "+12075632668", "display_phone":
+        "(207) 563-2668", "distance": 14789.019101331081}, {"id": "QvfAnmU7rbqCkWZcBlPulw",
+        "alias": "midcoast-yoga-shala-damariscotta", "name": "Midcoast Yoga Shala",
+        "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/igWz34TMbenbhxSTfIO7LQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/midcoast-yoga-shala-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.0332339704037, "longitude": -69.5331358909607},
+        "transactions": [], "location": {"address1": "49 Main St", "address2": "Ste
+        4", "address3": "", "city": "Damariscotta", "zip_code": "04543", "country":
+        "US", "state": "ME", "display_address": ["49 Main St", "Ste 4", "Damariscotta,
+        ME 04543"]}, "phone": "+12075631917", "display_phone": "(207) 563-1917", "distance":
+        15720.189869122167}, {"id": "On6mAeQjrMMuRwEc7eonVQ", "alias": "soma-rockland",
+        "name": "Soma", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/soma-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 1.0, "coordinates": {"latitude": 44.10384, "longitude": -69.10901},
+        "transactions": [], "location": {"address1": "385 Main St", "address2": "Ste
+        3", "address3": "", "city": "Rockland", "zip_code": "04841", "country": "US",
+        "state": "ME", "display_address": ["385 Main St", "Ste 3", "Rockland, ME 04841"]},
+        "phone": "+12075966177", "display_phone": "(207) 596-6177", "distance": 20562.333210206318},
+        {"id": "80XRogbI6fUCQc6r2fcOnw", "alias": "planet-fitness-rockland", "name":
+        "Planet Fitness", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/e1N7-6kzc4SVNQeB5YHD5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/planet-fitness-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 44.117653, "longitude": -69.10884}, "transactions":
+        [], "location": {"address1": "75 Maverick St", "address2": "", "address3":
+        null, "city": "Rockland", "zip_code": "04841", "country": "US", "state": "ME",
+        "display_address": ["75 Maverick St", "Rockland, ME 04841"]}, "phone": "+12074183111",
+        "display_phone": "(207) 418-3111", "distance": 20581.75182096001}, {"id":
+        "_9_amlJVk5SIQRcUAB_jmQ", "alias": "earth-flow-fire-and-earth-candy-rockland",
+        "name": "Earth Flow + Fire and Earth Candy", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Tjv9n6IU65Z2VkdCd-_RIQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/earth-flow-fire-and-earth-candy-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 14, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "juicebars", "title": "Juice Bars & Smoothies"}, {"alias": "vegan", "title":
+        "Vegan"}], "rating": 4.0, "coordinates": {"latitude": 44.103983090593, "longitude":
+        -69.1083925317452}, "transactions": [], "location": {"address1": "385 Main
+        St", "address2": "", "address3": null, "city": "Rockland", "zip_code": "04841",
+        "country": "US", "state": "ME", "display_address": ["385 Main St", "Rockland,
+        ME 04841"]}, "phone": "+12075938269", "display_phone": "(207) 593-8269", "distance":
+        20597.602993219323}, {"id": "wtzdNWtMkw2Eaz9Mx7iZ1w", "alias": "rockland-ymca-program-center-rockland",
+        "name": "Rockland YMCA Program Center", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/MnMxJUivVtpdQ3gG-l_UCw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/rockland-ymca-program-center-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.098741, "longitude": -69.10767}, "transactions": [], "location":
+        {"address1": "12 Water St", "address2": null, "address3": null, "city": "Rockland",
+        "zip_code": "04841", "country": "US", "state": "ME", "display_address": ["12
+        Water St", "Rockland, ME 04841"]}, "phone": "+12075938500", "display_phone":
+        "(207) 593-8500", "distance": 20677.358933719544}, {"id": "2taLnHxJ1_EdjmXVAmDLxA",
+        "alias": "cj-strength-and-conditioning-rockport", "name": "CJ Strength & Conditioning",
+        "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/aAjB1orXLXDnK2KESwou_w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/cj-strength-and-conditioning-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "cardioclasses", "title": "Cardio Classes"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.179257, "longitude": -69.0806955}, "transactions": [], "location":
+        {"address1": "321 Commercial St", "address2": null, "address3": null, "city":
+        "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["321 Commercial St", "Rockport, ME 04856"]}, "phone": "+12075923004", "display_phone":
+        "(207) 592-3004", "distance": 24123.465792882624}, {"id": "21v8vUQKyTw7KCzXU6gI3g",
+        "alias": "penobscot-bay-ymca-rockport", "name": "Penobscot Bay YMCA", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/penobscot-bay-ymca-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.1961784362793, "longitude": -69.0691833496094}, "transactions":
+        [], "location": {"address1": "116 Union St", "address2": "", "address3": "",
+        "city": "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["116 Union St", "Rockport, ME 04856"]}, "phone": "+12072363375", "display_phone":
+        "(207) 236-3375", "distance": 25659.941679247007}, {"id": "dpuB_TvHgu_WctnwthxRiA",
+        "alias": "sanctuary-day-spa-camden", "name": "Sanctuary Day Spa", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/sanctuary-day-spa-camden?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "spas", "title": "Day Spas"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 3.5, "coordinates": {"latitude":
+        44.2040657, "longitude": -69.0726015}, "transactions": [], "price": "$$",
+        "location": {"address1": "91 Elm St", "address2": null, "address3": null,
+        "city": "Camden", "zip_code": "04843", "country": "US", "state": "ME", "display_address":
+        ["91 Elm St", "Camden, ME 04843"]}, "phone": "+12072363338", "display_phone":
+        "(207) 236-3338", "distance": 25745.315927455682}, {"id": "qa60MAw_u80AUPLybkOzZg",
+        "alias": "madilyns-camden-3", "name": "Madilyn''s", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/IMJfvrbzf0KqXZIv80Wn7w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/madilyns-camden-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "psychics", "title": "Psychics"},
+        {"alias": "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 3.5, "coordinates": {"latitude": 44.21091,
+        "longitude": -69.06478}, "transactions": [], "location": {"address1": "43
+        Main St", "address2": "", "address3": null, "city": "Camden", "zip_code":
+        "04843", "country": "US", "state": "ME", "display_address": ["43 Main St",
+        "Camden, ME 04843"]}, "phone": "+12075424555", "display_phone": "(207) 542-4555",
+        "distance": 26630.590700280754}, {"id": "uHOhyvQsJrnycDvYP0vsdA", "alias":
+        "wicked-good-yoga-wiscasset", "name": "Wicked Good Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/47unwsbyeHOxRiD7oT86nQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/wicked-good-yoga-wiscasset?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 6, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.00408, "longitude": -69.67283}, "transactions":
+        [], "location": {"address1": "5 Bradford Rd", "address2": "", "address3":
+        "", "city": "Wiscasset", "zip_code": "04578", "country": "US", "state": "ME",
+        "display_address": ["5 Bradford Rd", "Wiscasset, ME 04578"]}, "phone": "+12078826892",
+        "display_phone": "(207) 882-6892", "distance": 27038.20224433696}, {"id":
+        "2-ci-AfKX_TYKxvlbCdV3A", "alias": "boothbay-region-ymca-boothbay-harbor",
+        "name": "Boothbay Region YMCA", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/boothbay-region-ymca-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "childcare", "title": "Child Care
+        & Day Care"}, {"alias": "gyms", "title": "Gyms"}], "rating": 5.0, "coordinates":
+        {"latitude": 43.8642996808783, "longitude": -69.6283435821533}, "transactions":
+        [], "location": {"address1": "261 Townsend Ave", "address2": "", "address3":
+        "", "city": "Boothbay Harbor", "zip_code": "04538", "country": "US", "state":
+        "ME", "display_address": ["261 Townsend Ave", "Boothbay Harbor, ME 04538"]},
+        "phone": "+12076332855", "display_phone": "(207) 633-2855", "distance": 34270.9382916149},
+        {"id": "wkY7O81rP18it8hSC4BzwQ", "alias": "crow-point-yoga-boothbay-harbor",
+        "name": "Crow Point Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/crow-point-yoga-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "massage_therapy", "title": "Massage
+        Therapy"}], "rating": 5.0, "coordinates": {"latitude": 43.8533761500391, "longitude":
+        -69.6285690454027}, "transactions": [], "location": {"address1": "24 W St",
+        "address2": "", "address3": null, "city": "Boothbay Harbor", "zip_code": "04538",
+        "country": "US", "state": "ME", "display_address": ["24 W St", "Boothbay Harbor,
+        ME 04538"]}, "phone": "", "display_phone": "", "distance": 35251.51157714305},
+        {"id": "KUk7LSXAsq9bkMdYwZfutA", "alias": "monhegan-wellness-monhegan", "name":
+        "Monhegan Wellness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/tDFdYzvnSYZOOTaezVYeyg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/monhegan-wellness-monhegan?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 4.0, "coordinates": {"latitude":
+        43.7629341277025, "longitude": -69.3182531346405}, "transactions": [], "location":
+        {"address1": "60 Woods End Ln", "address2": null, "address3": "", "city":
+        "Monhegan", "zip_code": "04852", "country": "US", "state": "ME", "display_address":
+        ["60 Woods End Ln", "Monhegan, ME 04852"]}, "phone": "+12072102544", "display_phone":
+        "(207) 210-2544", "distance": 38574.21034800724}, {"id": "4vyERxBDisUowGzt6fjDiA",
+        "alias": "mainely-gymnastics-augusta", "name": "Mainely Gymnastics", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/mainely-gymnastics-augusta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "fitness", "title": "Fitness &
+        Instruction"}, {"alias": "gymnastics", "title": "Gymnastics"}], "rating":
+        4.0, "coordinates": {"latitude": 44.3762287783817, "longitude": -69.723171409252},
+        "transactions": [], "location": {"address1": "994 Riverside Dr", "address2":
+        "", "address3": "", "city": "Augusta", "zip_code": "04330", "country": "US",
+        "state": "ME", "display_address": ["994 Riverside Dr", "Augusta, ME 04330"]},
+        "phone": "+12076229584", "display_phone": "(207) 622-9584", "distance": 41221.549666033716},
+        {"id": "_KpYvJmQdxnsizYJAeflUw", "alias": "waldo-county-ymca-belfast", "name":
+        "Waldo County YMCA", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/A-QLD2nUiLD_W2HCtHX21Q/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/waldo-county-ymca-belfast?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 3.5, "coordinates":
+        {"latitude": 44.4140573590994, "longitude": -69.022863060236}, "transactions":
+        [], "location": {"address1": "157 Lincolnville Ave", "address2": "", "address3":
+        "", "city": "Belfast", "zip_code": "04915", "country": "US", "state": "ME",
+        "display_address": ["157 Lincolnville Ave", "Belfast, ME 04915"]}, "phone":
+        "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
+        "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
+        44.10811081310502}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:35 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=04572&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 7f7c117d9009d931
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-g7g2v; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Remaining:
+      - '4982'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-98-90-uswest2aprod
+      X-Extlb:
+      - 10-69-98-90-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:35 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8257-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "RI8Gd94NEgZMuPJLCCXc5A", "alias": "ocean-blue-fitness-damariscotta",
+        "name": "Ocean Blue Fitness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/Dpp_3Mn5OLs7IsOI5SqARg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ocean-blue-fitness-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "pilates", "title": "Pilates"},
+        {"alias": "healthtrainers", "title": "Trainers"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.03321, "longitude": -69.51981}, "transactions": [], "location":
+        {"address1": "64 Chapman St", "address2": "", "address3": null, "city": "Damariscotta",
+        "zip_code": "04543", "country": "US", "state": "ME", "display_address": ["64
+        Chapman St", "Damariscotta, ME 04543"]}, "phone": "+12075632668", "display_phone":
+        "(207) 563-2668", "distance": 14789.019101331081}, {"id": "QvfAnmU7rbqCkWZcBlPulw",
+        "alias": "midcoast-yoga-shala-damariscotta", "name": "Midcoast Yoga Shala",
+        "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/igWz34TMbenbhxSTfIO7LQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/midcoast-yoga-shala-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.0332339704037, "longitude": -69.5331358909607},
+        "transactions": [], "location": {"address1": "49 Main St", "address2": "Ste
+        4", "address3": "", "city": "Damariscotta", "zip_code": "04543", "country":
+        "US", "state": "ME", "display_address": ["49 Main St", "Ste 4", "Damariscotta,
+        ME 04543"]}, "phone": "+12075631917", "display_phone": "(207) 563-1917", "distance":
+        15720.189869122167}, {"id": "On6mAeQjrMMuRwEc7eonVQ", "alias": "soma-rockland",
+        "name": "Soma", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/soma-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 1.0, "coordinates": {"latitude": 44.10384, "longitude": -69.10901},
+        "transactions": [], "location": {"address1": "385 Main St", "address2": "Ste
+        3", "address3": "", "city": "Rockland", "zip_code": "04841", "country": "US",
+        "state": "ME", "display_address": ["385 Main St", "Ste 3", "Rockland, ME 04841"]},
+        "phone": "+12075966177", "display_phone": "(207) 596-6177", "distance": 20562.333210206318},
+        {"id": "80XRogbI6fUCQc6r2fcOnw", "alias": "planet-fitness-rockland", "name":
+        "Planet Fitness", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/e1N7-6kzc4SVNQeB5YHD5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/planet-fitness-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 44.117653, "longitude": -69.10884}, "transactions":
+        [], "location": {"address1": "75 Maverick St", "address2": "", "address3":
+        null, "city": "Rockland", "zip_code": "04841", "country": "US", "state": "ME",
+        "display_address": ["75 Maverick St", "Rockland, ME 04841"]}, "phone": "+12074183111",
+        "display_phone": "(207) 418-3111", "distance": 20581.75182096001}, {"id":
+        "_9_amlJVk5SIQRcUAB_jmQ", "alias": "earth-flow-fire-and-earth-candy-rockland",
+        "name": "Earth Flow + Fire and Earth Candy", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Tjv9n6IU65Z2VkdCd-_RIQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/earth-flow-fire-and-earth-candy-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 14, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "juicebars", "title": "Juice Bars & Smoothies"}, {"alias": "vegan", "title":
+        "Vegan"}], "rating": 4.0, "coordinates": {"latitude": 44.103983090593, "longitude":
+        -69.1083925317452}, "transactions": [], "location": {"address1": "385 Main
+        St", "address2": "", "address3": null, "city": "Rockland", "zip_code": "04841",
+        "country": "US", "state": "ME", "display_address": ["385 Main St", "Rockland,
+        ME 04841"]}, "phone": "+12075938269", "display_phone": "(207) 593-8269", "distance":
+        20597.602993219323}, {"id": "wtzdNWtMkw2Eaz9Mx7iZ1w", "alias": "rockland-ymca-program-center-rockland",
+        "name": "Rockland YMCA Program Center", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/MnMxJUivVtpdQ3gG-l_UCw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/rockland-ymca-program-center-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.098741, "longitude": -69.10767}, "transactions": [], "location":
+        {"address1": "12 Water St", "address2": null, "address3": null, "city": "Rockland",
+        "zip_code": "04841", "country": "US", "state": "ME", "display_address": ["12
+        Water St", "Rockland, ME 04841"]}, "phone": "+12075938500", "display_phone":
+        "(207) 593-8500", "distance": 20677.358933719544}, {"id": "2taLnHxJ1_EdjmXVAmDLxA",
+        "alias": "cj-strength-and-conditioning-rockport", "name": "CJ Strength & Conditioning",
+        "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/aAjB1orXLXDnK2KESwou_w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/cj-strength-and-conditioning-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "cardioclasses", "title": "Cardio Classes"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.179257, "longitude": -69.0806955}, "transactions": [], "location":
+        {"address1": "321 Commercial St", "address2": null, "address3": null, "city":
+        "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["321 Commercial St", "Rockport, ME 04856"]}, "phone": "+12075923004", "display_phone":
+        "(207) 592-3004", "distance": 24123.465792882624}, {"id": "21v8vUQKyTw7KCzXU6gI3g",
+        "alias": "penobscot-bay-ymca-rockport", "name": "Penobscot Bay YMCA", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/penobscot-bay-ymca-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.1961784362793, "longitude": -69.0691833496094}, "transactions":
+        [], "location": {"address1": "116 Union St", "address2": "", "address3": "",
+        "city": "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["116 Union St", "Rockport, ME 04856"]}, "phone": "+12072363375", "display_phone":
+        "(207) 236-3375", "distance": 25659.941679247007}, {"id": "dpuB_TvHgu_WctnwthxRiA",
+        "alias": "sanctuary-day-spa-camden", "name": "Sanctuary Day Spa", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/sanctuary-day-spa-camden?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "spas", "title": "Day Spas"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 3.5, "coordinates": {"latitude":
+        44.2040657, "longitude": -69.0726015}, "transactions": [], "price": "$$",
+        "location": {"address1": "91 Elm St", "address2": null, "address3": null,
+        "city": "Camden", "zip_code": "04843", "country": "US", "state": "ME", "display_address":
+        ["91 Elm St", "Camden, ME 04843"]}, "phone": "+12072363338", "display_phone":
+        "(207) 236-3338", "distance": 25745.315927455682}, {"id": "qa60MAw_u80AUPLybkOzZg",
+        "alias": "madilyns-camden-3", "name": "Madilyn''s", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/IMJfvrbzf0KqXZIv80Wn7w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/madilyns-camden-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "psychics", "title": "Psychics"},
+        {"alias": "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 3.5, "coordinates": {"latitude": 44.21091,
+        "longitude": -69.06478}, "transactions": [], "location": {"address1": "43
+        Main St", "address2": "", "address3": null, "city": "Camden", "zip_code":
+        "04843", "country": "US", "state": "ME", "display_address": ["43 Main St",
+        "Camden, ME 04843"]}, "phone": "+12075424555", "display_phone": "(207) 542-4555",
+        "distance": 26630.590700280754}, {"id": "uHOhyvQsJrnycDvYP0vsdA", "alias":
+        "wicked-good-yoga-wiscasset", "name": "Wicked Good Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/47unwsbyeHOxRiD7oT86nQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/wicked-good-yoga-wiscasset?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 6, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.00408, "longitude": -69.67283}, "transactions":
+        [], "location": {"address1": "5 Bradford Rd", "address2": "", "address3":
+        "", "city": "Wiscasset", "zip_code": "04578", "country": "US", "state": "ME",
+        "display_address": ["5 Bradford Rd", "Wiscasset, ME 04578"]}, "phone": "+12078826892",
+        "display_phone": "(207) 882-6892", "distance": 27038.20224433696}, {"id":
+        "2-ci-AfKX_TYKxvlbCdV3A", "alias": "boothbay-region-ymca-boothbay-harbor",
+        "name": "Boothbay Region YMCA", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/boothbay-region-ymca-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "childcare", "title": "Child Care
+        & Day Care"}, {"alias": "gyms", "title": "Gyms"}], "rating": 5.0, "coordinates":
+        {"latitude": 43.8642996808783, "longitude": -69.6283435821533}, "transactions":
+        [], "location": {"address1": "261 Townsend Ave", "address2": "", "address3":
+        "", "city": "Boothbay Harbor", "zip_code": "04538", "country": "US", "state":
+        "ME", "display_address": ["261 Townsend Ave", "Boothbay Harbor, ME 04538"]},
+        "phone": "+12076332855", "display_phone": "(207) 633-2855", "distance": 34270.9382916149},
+        {"id": "wkY7O81rP18it8hSC4BzwQ", "alias": "crow-point-yoga-boothbay-harbor",
+        "name": "Crow Point Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/crow-point-yoga-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "massage_therapy", "title": "Massage
+        Therapy"}], "rating": 5.0, "coordinates": {"latitude": 43.8533761500391, "longitude":
+        -69.6285690454027}, "transactions": [], "location": {"address1": "24 W St",
+        "address2": "", "address3": null, "city": "Boothbay Harbor", "zip_code": "04538",
+        "country": "US", "state": "ME", "display_address": ["24 W St", "Boothbay Harbor,
+        ME 04538"]}, "phone": "", "display_phone": "", "distance": 35251.51157714305},
+        {"id": "KUk7LSXAsq9bkMdYwZfutA", "alias": "monhegan-wellness-monhegan", "name":
+        "Monhegan Wellness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/tDFdYzvnSYZOOTaezVYeyg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/monhegan-wellness-monhegan?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 4.0, "coordinates": {"latitude":
+        43.7629341277025, "longitude": -69.3182531346405}, "transactions": [], "location":
+        {"address1": "60 Woods End Ln", "address2": null, "address3": "", "city":
+        "Monhegan", "zip_code": "04852", "country": "US", "state": "ME", "display_address":
+        ["60 Woods End Ln", "Monhegan, ME 04852"]}, "phone": "+12072102544", "display_phone":
+        "(207) 210-2544", "distance": 38574.21034800724}, {"id": "4vyERxBDisUowGzt6fjDiA",
+        "alias": "mainely-gymnastics-augusta", "name": "Mainely Gymnastics", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/mainely-gymnastics-augusta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "fitness", "title": "Fitness &
+        Instruction"}, {"alias": "gymnastics", "title": "Gymnastics"}], "rating":
+        4.0, "coordinates": {"latitude": 44.3762287783817, "longitude": -69.723171409252},
+        "transactions": [], "location": {"address1": "994 Riverside Dr", "address2":
+        "", "address3": "", "city": "Augusta", "zip_code": "04330", "country": "US",
+        "state": "ME", "display_address": ["994 Riverside Dr", "Augusta, ME 04330"]},
+        "phone": "+12076229584", "display_phone": "(207) 622-9584", "distance": 41221.549666033716},
+        {"id": "_KpYvJmQdxnsizYJAeflUw", "alias": "waldo-county-ymca-belfast", "name":
+        "Waldo County YMCA", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/A-QLD2nUiLD_W2HCtHX21Q/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/waldo-county-ymca-belfast?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 3.5, "coordinates":
+        {"latitude": 44.4140573590994, "longitude": -69.022863060236}, "transactions":
+        [], "location": {"address1": "157 Lincolnville Ave", "address2": "", "address3":
+        "", "city": "Belfast", "zip_code": "04915", "country": "US", "state": "ME",
+        "display_address": ["157 Lincolnville Ave", "Belfast, ME 04915"]}, "phone":
+        "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
+        "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
+        44.10811081310502}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_an_invalid_location_is_provided/returns_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_an_invalid_location_is_provided/returns_an_error.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=34112352323234545&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - f8372a72ed72c937
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-hpz29; site=public_api_v3
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-87-203-uswest2aprod
+      X-Extlb:
+      - 10-69-87-203-uswest2aprod
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:38 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8252-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"error": {"code": "LOCATION_NOT_FOUND", "description": "Could not
+        execute search, try specifying a more exact location."}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:38 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=89405&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Zipkin-Id:
+      - 429cf6a5925084ad
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-rqzbz; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4976'
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-117-142-uswest2aprod
+      X-Extlb:
+      - 10-69-117-142-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:43 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8267-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
+        "latitude": 40.4462157989704}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:43 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=23452345632456334%5B%5D&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-9k2wt; site=public_api_v3
+      Server:
+      - envoy
+      X-Zipkin-Id:
+      - f027757dd6b22be0
+      X-B3-Sampled:
+      - '0'
+      X-Proxied:
+      - 10-69-152-99-uswest2bprod
+      X-Extlb:
+      - 10-69-152-99-uswest2bprod
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:43 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8233-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: '{"error": {"code": "LOCATION_NOT_FOUND", "description": "Could not
+        execute search, try specifying a more exact location."}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:43 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -1,0 +1,220 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=04572&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-8xxzf; site=public_api_v3
+      X-Zipkin-Id:
+      - 3dd25f33d61305dc
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Remaining:
+      - '4977'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-84-252-uswest2aprod
+      X-Extlb:
+      - 10-69-84-252-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:42 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8247-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "RI8Gd94NEgZMuPJLCCXc5A", "alias": "ocean-blue-fitness-damariscotta",
+        "name": "Ocean Blue Fitness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/Dpp_3Mn5OLs7IsOI5SqARg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ocean-blue-fitness-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "pilates", "title": "Pilates"},
+        {"alias": "healthtrainers", "title": "Trainers"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.03321, "longitude": -69.51981}, "transactions": [], "location":
+        {"address1": "64 Chapman St", "address2": "", "address3": null, "city": "Damariscotta",
+        "zip_code": "04543", "country": "US", "state": "ME", "display_address": ["64
+        Chapman St", "Damariscotta, ME 04543"]}, "phone": "+12075632668", "display_phone":
+        "(207) 563-2668", "distance": 14789.019101331081}, {"id": "QvfAnmU7rbqCkWZcBlPulw",
+        "alias": "midcoast-yoga-shala-damariscotta", "name": "Midcoast Yoga Shala",
+        "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/igWz34TMbenbhxSTfIO7LQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/midcoast-yoga-shala-damariscotta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.0332339704037, "longitude": -69.5331358909607},
+        "transactions": [], "location": {"address1": "49 Main St", "address2": "Ste
+        4", "address3": "", "city": "Damariscotta", "zip_code": "04543", "country":
+        "US", "state": "ME", "display_address": ["49 Main St", "Ste 4", "Damariscotta,
+        ME 04543"]}, "phone": "+12075631917", "display_phone": "(207) 563-1917", "distance":
+        15720.189869122167}, {"id": "On6mAeQjrMMuRwEc7eonVQ", "alias": "soma-rockland",
+        "name": "Soma", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/soma-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 1.0, "coordinates": {"latitude": 44.10384, "longitude": -69.10901},
+        "transactions": [], "location": {"address1": "385 Main St", "address2": "Ste
+        3", "address3": "", "city": "Rockland", "zip_code": "04841", "country": "US",
+        "state": "ME", "display_address": ["385 Main St", "Ste 3", "Rockland, ME 04841"]},
+        "phone": "+12075966177", "display_phone": "(207) 596-6177", "distance": 20562.333210206318},
+        {"id": "80XRogbI6fUCQc6r2fcOnw", "alias": "planet-fitness-rockland", "name":
+        "Planet Fitness", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/e1N7-6kzc4SVNQeB5YHD5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/planet-fitness-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 44.117653, "longitude": -69.10884}, "transactions":
+        [], "location": {"address1": "75 Maverick St", "address2": "", "address3":
+        null, "city": "Rockland", "zip_code": "04841", "country": "US", "state": "ME",
+        "display_address": ["75 Maverick St", "Rockland, ME 04841"]}, "phone": "+12074183111",
+        "display_phone": "(207) 418-3111", "distance": 20581.75182096001}, {"id":
+        "_9_amlJVk5SIQRcUAB_jmQ", "alias": "earth-flow-fire-and-earth-candy-rockland",
+        "name": "Earth Flow + Fire and Earth Candy", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Tjv9n6IU65Z2VkdCd-_RIQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/earth-flow-fire-and-earth-candy-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 14, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "juicebars", "title": "Juice Bars & Smoothies"}, {"alias": "vegan", "title":
+        "Vegan"}], "rating": 4.0, "coordinates": {"latitude": 44.103983090593, "longitude":
+        -69.1083925317452}, "transactions": [], "location": {"address1": "385 Main
+        St", "address2": "", "address3": null, "city": "Rockland", "zip_code": "04841",
+        "country": "US", "state": "ME", "display_address": ["385 Main St", "Rockland,
+        ME 04841"]}, "phone": "+12075938269", "display_phone": "(207) 593-8269", "distance":
+        20597.602993219323}, {"id": "wtzdNWtMkw2Eaz9Mx7iZ1w", "alias": "rockland-ymca-program-center-rockland",
+        "name": "Rockland YMCA Program Center", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/MnMxJUivVtpdQ3gG-l_UCw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/rockland-ymca-program-center-rockland?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.098741, "longitude": -69.10767}, "transactions": [], "location":
+        {"address1": "12 Water St", "address2": null, "address3": null, "city": "Rockland",
+        "zip_code": "04841", "country": "US", "state": "ME", "display_address": ["12
+        Water St", "Rockland, ME 04841"]}, "phone": "+12075938500", "display_phone":
+        "(207) 593-8500", "distance": 20677.358933719544}, {"id": "2taLnHxJ1_EdjmXVAmDLxA",
+        "alias": "cj-strength-and-conditioning-rockport", "name": "CJ Strength & Conditioning",
+        "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/aAjB1orXLXDnK2KESwou_w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/cj-strength-and-conditioning-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "cardioclasses", "title": "Cardio Classes"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.179257, "longitude": -69.0806955}, "transactions": [], "location":
+        {"address1": "321 Commercial St", "address2": null, "address3": null, "city":
+        "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["321 Commercial St", "Rockport, ME 04856"]}, "phone": "+12075923004", "display_phone":
+        "(207) 592-3004", "distance": 24123.465792882624}, {"id": "21v8vUQKyTw7KCzXU6gI3g",
+        "alias": "penobscot-bay-ymca-rockport", "name": "Penobscot Bay YMCA", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/penobscot-bay-ymca-rockport?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 5.0, "coordinates":
+        {"latitude": 44.1961784362793, "longitude": -69.0691833496094}, "transactions":
+        [], "location": {"address1": "116 Union St", "address2": "", "address3": "",
+        "city": "Rockport", "zip_code": "04856", "country": "US", "state": "ME", "display_address":
+        ["116 Union St", "Rockport, ME 04856"]}, "phone": "+12072363375", "display_phone":
+        "(207) 236-3375", "distance": 25659.941679247007}, {"id": "dpuB_TvHgu_WctnwthxRiA",
+        "alias": "sanctuary-day-spa-camden", "name": "Sanctuary Day Spa", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/sanctuary-day-spa-camden?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "spas", "title": "Day Spas"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 3.5, "coordinates": {"latitude":
+        44.2040657, "longitude": -69.0726015}, "transactions": [], "price": "$$",
+        "location": {"address1": "91 Elm St", "address2": null, "address3": null,
+        "city": "Camden", "zip_code": "04843", "country": "US", "state": "ME", "display_address":
+        ["91 Elm St", "Camden, ME 04843"]}, "phone": "+12072363338", "display_phone":
+        "(207) 236-3338", "distance": 25745.315927455682}, {"id": "qa60MAw_u80AUPLybkOzZg",
+        "alias": "madilyns-camden-3", "name": "Madilyn''s", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/IMJfvrbzf0KqXZIv80Wn7w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/madilyns-camden-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "psychics", "title": "Psychics"},
+        {"alias": "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 3.5, "coordinates": {"latitude": 44.21091,
+        "longitude": -69.06478}, "transactions": [], "location": {"address1": "43
+        Main St", "address2": "", "address3": null, "city": "Camden", "zip_code":
+        "04843", "country": "US", "state": "ME", "display_address": ["43 Main St",
+        "Camden, ME 04843"]}, "phone": "+12075424555", "display_phone": "(207) 542-4555",
+        "distance": 26630.590700280754}, {"id": "uHOhyvQsJrnycDvYP0vsdA", "alias":
+        "wicked-good-yoga-wiscasset", "name": "Wicked Good Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/47unwsbyeHOxRiD7oT86nQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/wicked-good-yoga-wiscasset?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 6, "categories": [{"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "coordinates": {"latitude": 44.00408, "longitude": -69.67283}, "transactions":
+        [], "location": {"address1": "5 Bradford Rd", "address2": "", "address3":
+        "", "city": "Wiscasset", "zip_code": "04578", "country": "US", "state": "ME",
+        "display_address": ["5 Bradford Rd", "Wiscasset, ME 04578"]}, "phone": "+12078826892",
+        "display_phone": "(207) 882-6892", "distance": 27038.20224433696}, {"id":
+        "2-ci-AfKX_TYKxvlbCdV3A", "alias": "boothbay-region-ymca-boothbay-harbor",
+        "name": "Boothbay Region YMCA", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/boothbay-region-ymca-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "childcare", "title": "Child Care
+        & Day Care"}, {"alias": "gyms", "title": "Gyms"}], "rating": 5.0, "coordinates":
+        {"latitude": 43.8642996808783, "longitude": -69.6283435821533}, "transactions":
+        [], "location": {"address1": "261 Townsend Ave", "address2": "", "address3":
+        "", "city": "Boothbay Harbor", "zip_code": "04538", "country": "US", "state":
+        "ME", "display_address": ["261 Townsend Ave", "Boothbay Harbor, ME 04538"]},
+        "phone": "+12076332855", "display_phone": "(207) 633-2855", "distance": 34270.9382916149},
+        {"id": "wkY7O81rP18it8hSC4BzwQ", "alias": "crow-point-yoga-boothbay-harbor",
+        "name": "Crow Point Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/crow-point-yoga-boothbay-harbor?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "massage_therapy", "title": "Massage
+        Therapy"}], "rating": 5.0, "coordinates": {"latitude": 43.8533761500391, "longitude":
+        -69.6285690454027}, "transactions": [], "location": {"address1": "24 W St",
+        "address2": "", "address3": null, "city": "Boothbay Harbor", "zip_code": "04538",
+        "country": "US", "state": "ME", "display_address": ["24 W St", "Boothbay Harbor,
+        ME 04538"]}, "phone": "", "display_phone": "", "distance": 35251.51157714305},
+        {"id": "KUk7LSXAsq9bkMdYwZfutA", "alias": "monhegan-wellness-monhegan", "name":
+        "Monhegan Wellness", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/tDFdYzvnSYZOOTaezVYeyg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/monhegan-wellness-monhegan?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "yoga", "title": "Yoga"}], "rating": 4.0, "coordinates": {"latitude":
+        43.7629341277025, "longitude": -69.3182531346405}, "transactions": [], "location":
+        {"address1": "60 Woods End Ln", "address2": null, "address3": "", "city":
+        "Monhegan", "zip_code": "04852", "country": "US", "state": "ME", "display_address":
+        ["60 Woods End Ln", "Monhegan, ME 04852"]}, "phone": "+12072102544", "display_phone":
+        "(207) 210-2544", "distance": 38574.21034800724}, {"id": "4vyERxBDisUowGzt6fjDiA",
+        "alias": "mainely-gymnastics-augusta", "name": "Mainely Gymnastics", "image_url":
+        "", "is_closed": false, "url": "https://www.yelp.com/biz/mainely-gymnastics-augusta?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "fitness", "title": "Fitness &
+        Instruction"}, {"alias": "gymnastics", "title": "Gymnastics"}], "rating":
+        4.0, "coordinates": {"latitude": 44.3762287783817, "longitude": -69.723171409252},
+        "transactions": [], "location": {"address1": "994 Riverside Dr", "address2":
+        "", "address3": "", "city": "Augusta", "zip_code": "04330", "country": "US",
+        "state": "ME", "display_address": ["994 Riverside Dr", "Augusta, ME 04330"]},
+        "phone": "+12076229584", "display_phone": "(207) 622-9584", "distance": 41221.549666033716},
+        {"id": "_KpYvJmQdxnsizYJAeflUw", "alias": "waldo-county-ymca-belfast", "name":
+        "Waldo County YMCA", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/A-QLD2nUiLD_W2HCtHX21Q/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/waldo-county-ymca-belfast?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}], "rating": 3.5, "coordinates":
+        {"latitude": 44.4140573590994, "longitude": -69.022863060236}, "transactions":
+        [], "location": {"address1": "157 Lincolnville Ave", "address2": "", "address3":
+        "", "city": "Belfast", "zip_code": "04915", "country": "US", "state": "ME",
+        "display_address": ["157 Lincolnville Ave", "Belfast, ME 04915"]}, "phone":
+        "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
+        "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
+        44.10811081310502}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:43 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/YelpService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -1,0 +1,264 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/search?location=34145&radius=40000&sort_by=distance&term=gyms
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4978'
+      X-B3-Sampled:
+      - '0'
+      Server:
+      - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-pb6xh; site=public_api_v3
+      Ratelimit-Resettime:
+      - '2021-09-20T00:00:00+00:00'
+      X-Zipkin-Id:
+      - fcee5479fe6b3c6c
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-152-99-uswest2bprod
+      X-Extlb:
+      - 10-69-152-99-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 19 Sep 2021 03:46:42 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-den8239-DEN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"businesses": [{"id": "dYewYWV40roEGF9SzAHI5Q", "alias": "ambitions-wellness-and-body-coaching-marco-island",
+        "name": "Ambitions Wellness and Body Coaching", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/FOiNcgNgOtrz_54DrhFWzA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ambitions-wellness-and-body-coaching-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "yoga", "title": "Yoga"}, {"alias": "nutritionists", "title": "Nutritionists"}],
+        "rating": 5.0, "coordinates": {"latitude": 25.933615, "longitude": -81.698522},
+        "transactions": [], "location": {"address1": "1817 San Marco Rd", "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
+        FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
+        2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 4.0, "coordinates": {"latitude": 25.9341526, "longitude": -81.6989467},
+        "transactions": [], "price": "$$$", "location": {"address1": "1817 San Marco
+        Rd", "address2": null, "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["1817 San Marco
+        Rd", "Marco Island, FL 34145"]}, "phone": "+12393949235", "display_phone":
+        "(239) 394-9235", "distance": 2580.2116310113224}, {"id": "HxK5-XEhjl0x0RR9PAgBVQ",
+        "alias": "ymca-of-south-collier-marco-ymca-marco-island", "name": "YMCA of
+        South Collier-Marco YMCA", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/f3IWcztQgl8-9j1z8BsLdg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/ymca-of-south-collier-marco-ymca-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "childcare", "title": "Child Care & Day Care"}, {"alias": "healthtrainers",
+        "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude": 25.93536,
+        "longitude": -81.70816}, "transactions": [], "location": {"address1": "101
+        Sand Hill St", "address2": "", "address3": "", "city": "Marco Island", "zip_code":
+        "34145", "country": "US", "state": "FL", "display_address": ["101 Sand Hill
+        St", "Marco Island, FL 34145"]}, "phone": "+12393949622", "display_phone":
+        "(239) 394-9622", "distance": 3006.3576771165713}, {"id": "77ZmLGWFlgXoGie_p22wvQ",
+        "alias": "tender-touch-massage-marco-island", "name": "Tender Touch Massage",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/tender-touch-massage-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage_therapy", "title": "Massage Therapy"}, {"alias": "physicaltherapy",
+        "title": "Physical Therapy"}], "rating": 5.0, "coordinates": {"latitude":
+        25.9206, "longitude": -81.72583}, "transactions": [], "location": {"address1":
+        "651 S Collier Blvd", "address2": "", "address3": "", "city": "Marco Island",
+        "zip_code": "34145", "country": "US", "state": "FL", "display_address": ["651
+        S Collier Blvd", "Marco Island, FL 34145"]}, "phone": "+12393896999", "display_phone":
+        "(239) 389-6999", "distance": 3085.063199321182}, {"id": "5ri7jEdMHytwaNpuz89Veg",
+        "alias": "puresoul-personal-training-marco-island", "name": "PureSoul Personal
+        Training", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/U_8a5NOR7H5vwcPQ5TVVLg/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/puresoul-personal-training-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "nutritionists", "title": "Nutritionists"}, {"alias": "yoga", "title":
+        "Yoga"}], "rating": 5.0, "coordinates": {"latitude": 25.93563, "longitude":
+        -81.71219}, "transactions": [], "location": {"address1": null, "address2":
+        null, "address3": "", "city": "Marco Island", "zip_code": "34145", "country":
+        "US", "state": "FL", "display_address": ["Marco Island, FL 34145"]}, "phone":
+        "+14014407345", "display_phone": "(401) 440-7345", "distance": 3419.511245856647},
+        {"id": "uiOijFqy7BxDfOa2SlEGkQ", "alias": "revival-yoga-fitness-studio-marco-island",
+        "name": "Revival Yoga Fitness Studio", "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/sPbtQogiYGyyL_sFzgDurQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/revival-yoga-fitness-studio-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 10, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "pilates", "title": "Pilates"}], "rating": 4.5, "coordinates": {"latitude":
+        25.9543380737305, "longitude": -81.7285919189453}, "transactions": [], "location":
+        {"address1": "760 N Collier Blvd", "address2": "Ste 107", "address3": "",
+        "city": "Marco Island", "zip_code": "34145", "country": "US", "state": "FL",
+        "display_address": ["760 N Collier Blvd", "Ste 107", "Marco Island, FL 34145"]},
+        "phone": "+12393933400", "display_phone": "(239) 393-3400", "distance": 5780.626421179173},
+        {"id": "tk8UhlNErqTmL65pdkGR1g", "alias": "marco-fitness-club-marco-island",
+        "name": "Marco Fitness Club", "image_url": "", "is_closed": false, "url":
+        "https://www.yelp.com/biz/marco-fitness-club-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
+        "healthtrainers", "title": "Trainers"}], "rating": 4.0, "coordinates": {"latitude":
+        25.959680557251, "longitude": -81.7245101928711}, "transactions": [], "location":
+        {"address1": "871 E Elkcam Cir", "address2": "", "address3": "", "city": "Marco
+        Island", "zip_code": "34145", "country": "US", "state": "FL", "display_address":
+        ["871 E Elkcam Cir", "Marco Island, FL 34145"]}, "phone": "+12393943705",
+        "display_phone": "(239) 394-3705", "distance": 6126.426255565895}, {"id":
+        "xWJzfnHx8aEvi7l1Qcc19A", "alias": "1on1getfit-naples-2", "name": "1on1getfit",
+        "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CodR3jx8_45MItEASwNxpw/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/1on1getfit-naples-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "nutritionists", "title": "Nutritionists"},
+        {"alias": "healthtrainers", "title": "Trainers"}, {"alias": "weightlosscenters",
+        "title": "Weight Loss Centers"}], "rating": 5.0, "coordinates": {"latitude":
+        26.04595939009, "longitude": -81.6995589367082}, "transactions": [], "location":
+        {"address1": "6060 Collier Blvd", "address2": "", "address3": "", "city":
+        "Naples", "zip_code": "34114", "country": "US", "state": "FL", "display_address":
+        ["6060 Collier Blvd", "Naples, FL 34114"]}, "phone": "+12392937361", "display_phone":
+        "(239) 293-7361", "distance": 15068.754782760383}, {"id": "IZO8EwsTMxP6rLh-vvIkEg",
+        "alias": "hardcore-gym-naples", "name": "Hardcore Gym", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/1xIv8JLSpP8nPbF3upLB1w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/hardcore-gym-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 12, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.074733, "longitude": -81.7180927}, "transactions":
+        [], "location": {"address1": "11524 Tamiami Trl E", "address2": null, "address3":
+        "", "city": "Naples", "zip_code": "34113", "country": "US", "state": "FL",
+        "display_address": ["11524 Tamiami Trl E", "Naples, FL 34113"]}, "phone":
+        "+12397932639", "display_phone": "(239) 793-2639", "distance": 18386.506018478212},
+        {"id": "Gq1bUOCQXr7k83ZehwUVHA", "alias": "zumba-with-casta-naples", "name":
+        "Zumba With Casta", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/dOSEGQD82fwAdGClbcAb_A/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/zumba-with-casta-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.109026, "longitude": -81.76371},
+        "transactions": [], "location": {"address1": "3500 Thomasson Dr", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["3500 Thomasson Dr", "Naples, FL 34112"]},
+        "phone": "+12394652043", "display_phone": "(239) 465-2043", "distance": 22775.1597933018},
+        {"id": "t7kOb1q4uCY1trbrD7EdHw", "alias": "arts-and-hot-yoga-naples", "name":
+        "Arts & Hot Yoga", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/Y5P_MAnOdQx5_a9WRwdz3g/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/arts-and-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "meditationcenters", "title": "Meditation Centers"}, {"alias": "lifecoach",
+        "title": "Life Coach"}], "rating": 5.0, "coordinates": {"latitude": 26.11565,
+        "longitude": -81.75704}, "transactions": [], "location": {"address1": "4270
+        Tamiami Trl E", "address2": "Ste 16", "address3": "", "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["4270 Tamiami
+        Trl E", "Ste 16", "Naples, FL 34112"]}, "phone": "+12393001066", "display_phone":
+        "(239) 300-1066", "distance": 23530.63554890676}, {"id": "Ph-l7AABs7Bu1bCUFpalFA",
+        "alias": "the-sweet-science-boxing-naples", "name": "The Sweet Science Boxing",
+        "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/the-sweet-science-boxing-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "healthtrainers", "title": "Trainers"},
+        {"alias": "boxing", "title": "Boxing"}, {"alias": "gyms", "title": "Gyms"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.11565, "longitude": -81.75704},
+        "transactions": [], "location": {"address1": "4270 Tamiami Trl E", "address2":
+        "Ste 13", "address3": null, "city": "Naples", "zip_code": "34112", "country":
+        "US", "state": "FL", "display_address": ["4270 Tamiami Trl E", "Ste 13", "Naples,
+        FL 34112"]}, "phone": "+12397778732", "display_phone": "(239) 777-8732", "distance":
+        23589.542323878202}, {"id": "p3TYsD-nQ_H4H3qJINeF7w", "alias": "modern-steps-school-of-dance-naples",
+        "name": "Modern Steps School Of Dance", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/1D2QDCTc3Vj4I0MRMXjH5w/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/modern-steps-school-of-dance-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "theater", "title": "Performing
+        Arts"}, {"alias": "dancestudio", "title": "Dance Studios"}], "rating": 5.0,
+        "coordinates": {"latitude": 26.1168370216529, "longitude": -81.7553837189102},
+        "transactions": [], "location": {"address1": "4117 Tamiami Trl E", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["4117 Tamiami Trl E", "Naples, FL 34112"]},
+        "phone": "+12397753445", "display_phone": "(239) 775-3445", "distance": 23675.95011343892},
+        {"id": "ycYJSNH4cpkkHKj3ZlwTQQ", "alias": "pure-fitness-naples", "name": "Pure
+        Fitness", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/pure-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 1, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        5.0, "coordinates": {"latitude": 26.11957, "longitude": -81.75707}, "transactions":
+        [], "location": {"address1": "3831 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["3831 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12397937475",
+        "display_phone": "(239) 793-7475", "distance": 24009.201538904643}, {"id":
+        "-aD2laK768E7SRIU8PW6gg", "alias": "drip-hot-yoga-naples", "name": "Drip Hot
+        Yoga", "image_url": "", "is_closed": false, "url": "https://www.yelp.com/biz/drip-hot-yoga-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "yoga", "title": "Yoga"}, {"alias":
+        "massage", "title": "Massage"}], "rating": 5.0, "coordinates": {"latitude":
+        26.123462, "longitude": -81.770781}, "transactions": [], "location": {"address1":
+        "3212 Bayshore Dr", "address2": "", "address3": null, "city": "Naples", "zip_code":
+        "34112", "country": "US", "state": "FL", "display_address": ["3212 Bayshore
+        Dr", "Naples, FL 34112"]}, "phone": "+17274920096", "display_phone": "(727)
+        492-0096", "distance": 24803.13998889454}, {"id": "3rXE3wNkZCLQ0LdCmvq9oQ",
+        "alias": "trijake-fitness-naples", "name": "TriJake Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/XX7wqkahe16UVA2lKEYkSQ/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/trijake-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1281399, "longitude": -81.76079},
+        "transactions": [], "location": {"address1": "200 Palm Drive 43-3", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["200 Palm Drive 43-3", "Naples, FL 34112"]},
+        "phone": "", "display_phone": "", "distance": 25028.1569712333}, {"id": "V_cyxLoEfzDsixGPAtC6zw",
+        "alias": "planet-fitness-naples-3", "name": "Planet Fitness", "image_url":
+        "https://s3-media3.fl.yelpcdn.com/bphoto/Zf92fHClYDIoyb3pP6951g/o.jpg", "is_closed":
+        false, "url": "https://www.yelp.com/biz/planet-fitness-naples-3?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 20, "categories": [{"alias": "gyms", "title": "Gyms"}], "rating":
+        3.0, "coordinates": {"latitude": 26.129761, "longitude": -81.772522}, "transactions":
+        [], "location": {"address1": "2650 Tamiami Trl E", "address2": null, "address3":
+        null, "city": "Naples", "zip_code": "34112", "country": "US", "state": "FL",
+        "display_address": ["2650 Tamiami Trl E", "Naples, FL 34112"]}, "phone": "+12395449171",
+        "display_phone": "(239) 544-9171", "distance": 25523.59941699116}, {"id":
+        "MTphZhcEeHTGUCkwpM7tow", "alias": "tri-tone-triple-barre-fitness-naples",
+        "name": "Tri Tone Triple Barre Fitness", "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/SrrmAki7_MiVglr5R1gfWQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/tri-tone-triple-barre-fitness-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 5, "categories": [{"alias": "barreclasses", "title": "Barre
+        Classes"}], "rating": 5.0, "coordinates": {"latitude": 26.13678, "longitude":
+        -81.78163}, "transactions": [], "location": {"address1": "1800 Tamiami Trl
+        E", "address2": "", "address3": null, "city": "Naples", "zip_code": "34112",
+        "country": "US", "state": "FL", "display_address": ["1800 Tamiami Trl E",
+        "Naples, FL 34112"]}, "phone": "+12394041034", "display_phone": "(239) 404-1034",
+        "distance": 26556.36780934057}, {"id": "6_NmdY946RBKA9LYTr6l7A", "alias":
+        "infant-swimming-resource-naples-naples", "name": "Infant Swimming Resource
+        Naples", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/ow82YqVJ6h08bTPRPKeUJQ/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/infant-swimming-resource-naples-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 2, "categories": [{"alias": "swimminglessons", "title": "Swimming
+        Lessons/Schools"}, {"alias": "swimmingpools", "title": "Swimming Pools"}],
+        "rating": 3.0, "coordinates": {"latitude": 26.138722, "longitude": -81.780302},
+        "transactions": [], "location": {"address1": "1949 Davis Blvd", "address2":
+        "", "address3": "", "city": "Naples", "zip_code": "34104", "country": "US",
+        "state": "FL", "display_address": ["1949 Davis Blvd", "Naples, FL 34104"]},
+        "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896},
+        {"id": "xnuYs-1f9OlfRunVZHIlEA", "alias": "american-sports-karate-naples",
+        "name": "American Sports Karate", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/pI7kIqeZzULYmBN_DudMIA/o.jpg",
+        "is_closed": false, "url": "https://www.yelp.com/biz/american-sports-karate-naples?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "review_count": 3, "categories": [{"alias": "karate", "title": "Karate"}],
+        "rating": 5.0, "coordinates": {"latitude": 26.1505054, "longitude": -81.690138},
+        "transactions": [], "location": {"address1": "9950 Business Cir", "address2":
+        null, "address3": "", "city": "Naples", "zip_code": "34112", "country": "US",
+        "state": "FL", "display_address": ["9950 Business Cir", "Naples, FL 34112"]},
+        "phone": "+12396432275", "display_phone": "(239) 643-2275", "distance": 26700.711523141435}],
+        "total": 115, "region": {"center": {"longitude": -81.69708251953125, "latitude":
+        25.91046095897436}}}'
+  recorded_at: Sun, 19 Sep 2021 03:46:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/gym_spec.rb
+++ b/spec/models/gym_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Gym, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:yelp_gym_id) }
+    it { should validate_presence_of(:name) }
   end
 
   describe 'factories' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe User, type: :model do
                                           .class_name('Friendship')
                                           .dependent(:destroy)
                                           .inverse_of(:follower) }
-
     it { should have_many(:followees).through(:followed_users) }
+
     it { should have_many(:following_users).with_foreign_key(:followee_id)
                                            .class_name('Friendship')
                                            .dependent(:destroy)
                                            .inverse_of(:followee) }
-
     it { should have_many(:followers).through(:following_users) }
+
     it { should have_many(:events).dependent(:destroy) }
     it { should have_many(:gym_members).dependent(:destroy) }
     it { should have_many(:invitations).through(:events) }
@@ -85,6 +85,22 @@ RSpec.describe User, type: :model do
       expect(user.availability_afternoon).to be_in([true, false])
       expect(user.availability_evening).to be_in([true, false])
       expect(user.full_name).to be_a String
+    end
+  end
+
+  describe 'instance methods' do
+    let(:user) { user_with_gym }
+    let(:gym) { user.gyms.first }
+
+    let!(:past_event) { create(:event, date_time: DateTime.yesterday, user: user, gym: gym) }
+    let!(:upcoming_event_1) { create(:event, user: user, gym: gym) }
+    let!(:upcoming_event_2) { create(:event, user: user, gym: gym) }
+    let!(:upcoming_event_3) { create(:event, user: user, gym: gym) }
+
+    it 'can return upcoming_events for the user' do
+      expected = user.upcoming_events
+
+      expect(expected).to eq [upcoming_event_1, upcoming_event_2, upcoming_event_3]
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe User, type: :model do
                                           .class_name('Friendship')
                                           .dependent(:destroy)
                                           .inverse_of(:follower) }
+
     it { should have_many(:followees).through(:followed_users) }
 
     it { should have_many(:following_users).with_foreign_key(:followee_id)
                                            .class_name('Friendship')
                                            .dependent(:destroy)
                                            .inverse_of(:followee) }
+
     it { should have_many(:followers).through(:following_users) }
 
     it { should have_many(:events).dependent(:destroy) }
@@ -89,18 +91,34 @@ RSpec.describe User, type: :model do
   end
 
   describe 'instance methods' do
-    let(:user) { user_with_gym }
-    let(:gym) { user.gyms.first }
+    describe '#upcoming_events' do
+      let(:user) { user_with_gym }
+      let(:gym) { user.gyms.first }
 
-    let!(:past_event) { create(:event, date_time: DateTime.yesterday, user: user, gym: gym) }
-    let!(:upcoming_event_1) { create(:event, user: user, gym: gym) }
-    let!(:upcoming_event_2) { create(:event, user: user, gym: gym) }
-    let!(:upcoming_event_3) { create(:event, user: user, gym: gym) }
+      context 'when there are upcoming events' do
+        let!(:past_event) { create(:event, date_time: DateTime.yesterday, user: user, gym: gym) }
+        let!(:upcoming_event_1) { create(:event, user: user, gym: gym) }
+        let!(:upcoming_event_2) { create(:event, user: user, gym: gym) }
+        let!(:upcoming_event_3) { create(:event, user: user, gym: gym) }
 
-    it 'can return upcoming_events for the user' do
-      expected = user.upcoming_events
+        it 'returns the upcoming events for the user' do
+          expect(user.upcoming_events).to eq [upcoming_event_1, upcoming_event_2, upcoming_event_3]
+        end
+      end
 
-      expect(expected).to eq [upcoming_event_1, upcoming_event_2, upcoming_event_3]
+      context 'when there are no upcoming events' do
+        let!(:past_event) { create(:event, date_time: DateTime.yesterday, user: user, gym: gym) }
+
+        it 'can return an empty array' do
+          expect(user.upcoming_events).to be_empty
+        end
+      end
+
+      context 'when there are no events' do
+        it 'can return an empty array' do
+          expect(user.upcoming_events).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/poros/gym_from_search_spec.rb
+++ b/spec/poros/gym_from_search_spec.rb
@@ -1,37 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Gym do
-  describe 'Gym instantiation' do
-    before(:each) do
-      @response = {
-                    "id": "gHmS3WIjRRhSWG4OdCQYLA",
-                    "name": "Quest Fitness",
-                    "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=U3I_hTsM_rclzkCXyDmD1w&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=U3I_hTsM_rclzkCXyDmD1w",
-                    "review_count": 4,
-                    "rating": 5.0,
-                    "coordinates": {
-                        "latitude": 43.393861,
-                        "longitude": -70.527933
-                    },
-                    "location": {
-                        "city": "Kennebunk",
-                        "zip_code": "04043",
-                        "country": "US",
-                        "state": "ME",
-                        "display_address": [
-                            "2 Livewell Dr",
-                            "Kennebunk, ME 04043"
-                        ]
-                    },
-                    "display_phone": "(207) 467-3800",
-                    "distance": "3621.482123613702"
-                  }
+  describe 'Gym PORO initialization' do
+    let(:response) do
+      {
+        id: 'gHmS3WIjRRhSWG4OdCQYLA',
+        name: 'Quest Fitness',
+        url: 'https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=U3I_hTsM_rclzkCXyDmD1w&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=U3I_hTsM_rclzkCXyDmD1w',
+        review_count: 4,
+        rating: 5.0,
+        coordinates: {
+          latitude: 43.393861,
+          longitude: -70.527933
+        },
+        location: {
+          city: 'Kennebunk',
+          zip_code: '04043',
+          country: 'US',
+          state: 'ME',
+          display_address: [
+            '2 Livewell Dr',
+            'Kennebunk, ME 04043'
+          ]
+        },
+        display_phone: '(207) 467-3800',
+        distance: '3621.482123613702'
+      }
     end
+
     it 'creates a valid new gym with good params' do
-      new_gym = GymFromSearch.new(@response)
+      new_gym = GymFromSearch.new(response)
+
       expect(new_gym).to be_an_instance_of(GymFromSearch)
-      expect(new_gym.name).to eq("Quest Fitness")
-      expect(new_gym.address).to eq("2 Livewell Dr, Kennebunk, ME 04043")
+      expect(new_gym.name).to eq('Quest Fitness')
+      expect(new_gym.address).to eq('2 Livewell Dr, Kennebunk, ME 04043')
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,6 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  # update the following line when we actually have an API key
   config.filter_sensitive_data('DONT_SHARE_MY_SECRET_KEY') { ENV['yelp_api_key'] }
   config.default_cassette_options = { re_record_interval: 7.days }
   config.configure_rspec_metadata!

--- a/spec/requests/api/v1/gym_search/index_spec.rb
+++ b/spec/requests/api/v1/gym_search/index_spec.rb
@@ -16,47 +16,48 @@ describe 'GymSearch API', type: :request do
 
     context 'when a valid location is provided with a plethora of gyms' do
       it 'returns 20 nearby gyms sorted by distance', :aggregate_failures, :vcr do
-        get "/api/v1/gym_search?zip_code=34145"
+        get '/api/v1/gym_search?zip_code=34145'
         JSON.parse(response.body, symbolize_names: true)
 
-        expect(response.status).to eq(200)
+        expect(response.status).to eq 200
         expect(json).not_to be_empty
-        expect(json_data.size).to eq(20)
+        expect(json_data.size).to eq 20
         expect(json_data.first[:attributes][:yelp_gym_id]).to be_a(String)
       end
     end
 
     context 'when a valid location is provided with less than 20 available gyms' do
       it 'returns 20 nearby gyms sorted by distance', :aggregate_failures, :vcr do
-        get "/api/v1/gym_search?zip_code=04572"
+        get '/api/v1/gym_search?zip_code=04572'
         JSON.parse(response.body, symbolize_names: true)
 
-        expect(response.status).to eq(200)
+        expect(response.status).to eq 200
         expect(json).not_to be_empty
-        expect(json_data.size).to eq(16)
+        expect(json_data.size).to eq 16
         expect(json_data.first[:attributes][:yelp_gym_id]).to be_a(String)
       end
     end
 
     context 'when a valid location is provided but 0 gyms are nearby' do
       it 'returns 20 nearby gyms sorted by distance', :aggregate_failures, :vcr do
-        get "/api/v1/gym_search?zip_code=89405"
+        get '/api/v1/gym_search?zip_code=89405'
         JSON.parse(response.body, symbolize_names: true)
 
-        expect(response.status).to eq(200)
+        expect(response.status).to eq 200
         expect(json).not_to be_empty
-        expect(json_data.size).to eq(0)
+        expect(json_data.size).to eq 0
       end
     end
 
     context 'when an invalid location is provided' do
       it 'returns an error', :aggregate_failures, :vcr do
-        get "/api/v1/gym_search?zip_code=34112352323234545"
+        get '/api/v1/gym_search?zip_code=34112352323234545'
         JSON.parse(response.body, symbolize_names: true)
-        expect(response.status).to eq(400)
-        expect(json[:code]).to eq(400)
+
+        expect(response.status).to eq 400
+        expect(json[:code]).to eq 400
         expect(json[:error]).to eq({})
-        expect(json[:status]).to eq("Bad Request")
+        expect(json[:status]).to eq 'Bad Request'
       end
     end
   end

--- a/spec/requests/api/v1/users/events/index_request_spec.rb
+++ b/spec/requests/api/v1/users/events/index_request_spec.rb
@@ -19,6 +19,7 @@ describe 'Users::Events API', type: :request do
 
       it 'returns the users events', :aggregate_failures do
         expect(json).not_to be_empty
+
         expect(json_data.size).to eq(7)
         expect(json_data.first[:id]).to eq(event1_1a_2.id.to_s)
       end

--- a/spec/services/yelp_service_spec.rb
+++ b/spec/services/yelp_service_spec.rb
@@ -4,42 +4,49 @@ RSpec.describe YelpService do
   describe 'class methods' do
     describe '::connection_setup' do
       it 'successfully establishes the connection and defines the headers', :vcr do
-        setup = YelpService.connection_setup
+        setup = YelpService.conn
+        params = YelpService.params
+
         expect(setup.headers).to include('Authorization')
         expect(setup.headers.values).to include(ENV['yelp_api_key'])
+        expect(params).to eq 'term=gyms&radius=40000&sort_by=distance'
       end
     end
 
     describe '::gyms_near_user' do
-      context 'more than 20 gyms nearby' do
-        it 'retrieves the closest 20 gyms on Yelp within 40,000 meters of the users location', :vcr do
-          location = "34145"
-          results = YelpService.gyms_near_user(location)
+      context 'when more than 20 gyms nearby' do
+        it "retrieves the 20 closest gyms from Yelp within 40k meters of the user's location", :vcr do
+          zip_code = '34145'
+          results = YelpService.get_gyms(zip_code)
+
           expect(results[:businesses].count).to eq(20)
         end
       end
 
-      context 'less than 20 gyms nearby but more than 0' do
-        it 'retrieves all the closest gyms on yelp within 40k meters of location', :vcr do
-          location = "04572"
-          results = YelpService.gyms_near_user(location)
+      context 'when less than 20 gyms nearby but more than 0' do
+        it "retrieves the 20 closest gyms from Yelp within 40k meters of the user's location", :vcr do
+          zip_code = '04572'
+          results = YelpService.get_gyms(zip_code)
+
           expect(results[:businesses].count).to eq(16)
         end
       end
 
-      context '0 gyms nearby' do
+      context 'when 0 gyms nearby' do
         it 'retrieves an empty dataset, not an error', :vcr do
-          location = "89405"
-          results = YelpService.gyms_near_user(location)
+          zip_code = '89405'
+          results = YelpService.get_gyms(zip_code)
+
           expect(results[:businesses].count).to eq(0)
         end
       end
 
-      context 'bad location' do
+      context 'when bad zip code is queried' do
         it 'returns an error if the location provided is not found', :vcr do
-          location = "23452345632456334[]"
-          results = YelpService.gyms_near_user(location)
-          expect(results[:error][:code]).to eq("LOCATION_NOT_FOUND")
+          bad_zip = '23452345632456334[]'
+          results = YelpService.get_gyms(bad_zip)
+
+          expect(results[:error][:code]).to eq('LOCATION_NOT_FOUND')
         end
       end
     end


### PR DESCRIPTION
- Changes Implemented:
  - Added encrypted `yelp_api_key` to `.travis.yml`, and un-gitignored `cassettes` to get Travis builds to pass.  API key has been added to Heroku, so we won't have failing API calls after this PR is merged in
  - Created migration to add `name` to `Gym` table, factories, and as additional attribute to serializer, so the endpoint will render this for user `dashboard` view (currently only displaying `yelp_gym_id`)
  - Added helper method to `User` model for `upcoming_events`.  The `users/:id/events` endpoint now renders events from this method call (vs just `.events` prior)
  - Will be updating `/docs` as final step of this PR for refreshed endpoint examples based on DB-reseeding (PK's have changed the static URIs linked within ReadMe and docs)

- Quality Control Checklist:

  - [x] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
    - We have some infractions across the state of the repo, but most are due to pending examples, or longer method calls that we have already clarified comments to slim-up as todo items.
    - Suspecting that we will comb back through all of these during a later stage of the project
  - [x] 100% SimpleCov test coverage (if below, please clarify below)


- Blockers (if applicable):

- Next Steps & Additional Notes:
  - Need to reseed DB for FE team and update docs for endpoint examples
