### PR TITLE
Update seeds file to reset PKs with new routes for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ The following table presents each API endpoint and its associated documentation
 Endpoint | Docs | Example
 ---------|------|--------
 **Users** | [docs](/docs/users.md)
-Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31)
+Get Existing User | [docs](/docs/users.md#get-one-user) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1)
 Create New User | [docs](/docs/users.md#create-new-user) |
 Update Existing User | [docs](/docs/users.md#update-existing-user) |
-Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms)
-Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/friendships)
+Get User's Gyms | [docs](/docs/users.md#get-user-gyms) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/gym_memberships)
+Get User's Friends | [docs](/docs/users.md#get-user-friends) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/friendships)
 Add Friend | *pending* |
 Remove Friend | *pending* |
 **Events** | [docs](/docs/events.md)
-Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/31/events)
+Get User's Events | [docs](/docs/events.md#get-user-events) | [example](https://spotme-app-api.herokuapp.com/api/v1/users/1/events)
 Get User New Event | *pending* | *pending*
 Create User New Event | [docs](/docs/events#create-new-event.md) |
 **Gyms** | [docs](/docs/gyms.md)
 Get Gyms Near User | *pending* | *pending*
-Get Gym Show Page | [docs](/docs/gyms#get-gym.md) | [example](https://spotme-app-api.herokuapp.com/api/v1/gyms/16)
+Get Gym Show Page | *pending* | *pending*
 Add Gym Member | [docs](/docs/gyms#create-new-gym-member.md) |
 Remove Gym Member | [docs](/docs/gyms#remove-existing-gym-member.md) |
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 # require 'factory_bot_rails'
 include FactoryBot::Syntax::Methods
 
@@ -13,6 +5,11 @@ Friendship.destroy_all
 GymMembership.destroy_all
 Event.destroy_all
 User.destroy_all
+
+# reset PK's
+ActiveRecord::Base.connection.tables.each do |t|
+  ActiveRecord::Base.connection.reset_pk_sequence!(t)
+end
 
 # USERS
 user1 = create(:user, availability_morning: true)

--- a/docs/events.md
+++ b/docs/events.md
@@ -102,7 +102,7 @@ POST /users/{user_id}/gym_memberships/{gym_membership_id}/events
 Name       | Data Type    | In    | Required/Optional | Description
 -----------|--------------|-------|-------------------|------------
 `user_id` | String | Body | Required | The id of the user hosting the event.
-`gym_id` | String | Body | Required | The id of the gym the event will take place at.
+`gym_membership_id` | String | Body | Required | The id of the gym the event will take place at.
 `activity` | String | Body | Required | The activity (title) of the event.
 `date_time` | Datetime | Body | Required | The date and time of the event.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -3,7 +3,7 @@
 HTTP Verb | Endpoint                   | Description                | Link
 ----------|----------------------------|----------------------------|---------------------------
 GET       | `/users/{user_id}/events` | Get a user's events.     | [Link](#get-user-events)
-POST       | `/users/{user_id}/gyms/:gym_id/events` | Create a new event.     | [Link](#create-new-event)
+POST       | `/users/{user_id}/gym_memberships/{gym_membership_id}/events` | Create a new event.     | [Link](#create-new-event)
 
 
 ---
@@ -26,7 +26,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/31/events
+GET https://spotme-app-api.herokuapp.com/api/v1/users/1/events
 ```
 
 ### Example Response (Successful)
@@ -93,7 +93,7 @@ Status: 404 Not Found
 Create a new event based on provided attributes.
 
 ```
-POST /users/{user_id}/gyms/{gym_id}/events
+POST /users/{user_id}/gym_memberships/{gym_membership_id}/events
 ```
 
 
@@ -110,7 +110,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16/events
+POST https://spotme-app-api.herokuapp.com/api/v1/users/1/gym_memberships/1/events
 ```
 
 ### Example Response (Successful)

--- a/docs/gyms.md
+++ b/docs/gyms.md
@@ -21,8 +21,7 @@ POST /users/{user_id}/gym_memberships
 
 Name       | Data Type    | In    | Required/Optional | Description
 -----------|--------------|-------|-------------------|------------
-`user_id` | String | Body | Required | The id of the user record.
-`gym_id` | String | Body | Required | The id of the gym record.
+`user_id` | String | Parameters | Required | The id of the user record.
 
 
 ### Example Request
@@ -85,7 +84,7 @@ DELETE /users/{user_id}/gym_memberships/{gym_membership_id}
 Name       | Data Type    | In    | Required/Optional | Description
 -----------|--------------|-------|-------------------|------------
 `user_id` | String | Body | Required | The id of the user record.
-`gym_id` | String | Body | Required | The id of the gym record.
+`gym_membership_id` | String | Body | Required | The id of the gym record.
 
 
 ### Example Request

--- a/docs/gyms.md
+++ b/docs/gyms.md
@@ -2,60 +2,9 @@
 
 HTTP Verb | Endpoint                   | Description                | Link
 ----------|----------------------------|----------------------------|---------------------------
-GET       | `/gyms/{gym_id}` | Get a single gym.     | [Link](#get-gym)
-POST       | `/users/{user_id}/gyms/{gym_id}/gym_members` | Create a new gym member.     | [Link](#create-new-gym-member)
-DELETE       | `/users/{user_id}/gyms/{gym_id}` | Remove an existing gym member.     | [Link](#remove-existing-gym-member)
+POST       | `/users/{user_id}/gym_memberships` | Create a new gym member.     | [Link](#create-new-gym-member)
+DELETE       | `/users/{user_id}/gym_memberships/{gym_membership_id}` | Remove an existing gym member.     | [Link](#remove-existing-gym-member)
 
----
-
-## Get Gym
-
-Returns a gym and its attributes.
-
-```
-GET /gyms/{gym_id}
-```
-
-
-### Parameters
-
-Name       | Data Type    | In    | Required/Optional | Description
------------|--------------|-------|-------------------|------------
-`gym_id` | Integer | Path | Required | The ID of the gym.
-
-### Example Request
-
-```
-GET https://spotme-app-api.herokuapp.com/api/v1/gyms/16
-```
-
-### Example Response (Successful)
-
-```
-Status: 200 OK
-```
-
-```
-{:data=>
-  {:id=>"1654",
-   :type=>"gym",
-   :attributes=>{
-    :yelp_gym_id=>"preb6u3g2bot2u0ouivy02"
-    :name=>"Planet Fitness"}}
-}
-```
-
-### Example Response (Resource Not Found)
-
-```
-Status: 404 Not Found
-```
-
-```
-{:message=>"your query could not be completed",
-  :errors=>["Couldn't find Gym with 'id'=1684"]
-}
-```
 
 ---
 
@@ -64,7 +13,7 @@ Status: 404 Not Found
 Add a gym to the user's dashboard.
 
 ```
-POST /users/{user_id}/gyms/{gym_id}/gym_members
+POST /users/{user_id}/gym_memberships
 ```
 
 
@@ -79,7 +28,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-POST https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16/gym_members
+POST https://spotme-app-api.herokuapp.com/api/v1/users/1/gym_memberships
 ```
 
 ### Example Response (Successful)
@@ -127,7 +76,7 @@ Status: 404 Not Found
 Remove a gym from the user's dashboard.
 
 ```
-DELETE /users/{user_id}/gyms/{gym_id}
+DELETE /users/{user_id}/gym_memberships/{gym_membership_id}
 ```
 
 
@@ -142,7 +91,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-DELETE https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms/16
+DELETE https://spotme-app-api.herokuapp.com/api/v1/users/1/gym_memberships/1
 ```
 
 ### Example Response (No Content)

--- a/docs/users.md
+++ b/docs/users.md
@@ -5,7 +5,7 @@ HTTP Verb | Endpoint                   | Description                | Link
 GET       | `/users/{user_id}` | Get a single user.     | [Link](#get-one-user)
 POST       | `/users` | Create a new user.     | [Link](#create-new-user)
 PATCH       | `/users/{user_id}` | Update an existing user.     | [Link](#update-existing-user)
-GET       | `/users/{user_id}/gyms` | Get a user's gyms.     | [Link](#get-user-gyms)
+GET       | `/users/{user_id}/gym_memberships` | Get a user's gyms.     | [Link](#get-user-gyms)
 GET       | `/users/{user_id}/friendships` | Get a user's friends.     | [Link](#get-user-friends)
 
 ---
@@ -28,7 +28,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/31
+GET https://spotme-app-api.herokuapp.com/api/v1/users/1
 ```
 
 ### Example Response (Successful)
@@ -175,7 +175,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-PATCH https://spotme-app-api.herokuapp.com/api/v1/users/31
+PATCH https://spotme-app-api.herokuapp.com/api/v1/users/1
 ```
 
 ### Example Response (Successful)
@@ -226,7 +226,7 @@ Status: 422 Unprocessable Entity
 Returns a user and their associated gyms.
 
 ```
-GET /users/{user_id}/gyms
+GET /users/{user_id}/gym_memberships
 ```
 
 
@@ -239,7 +239,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/31/gyms
+GET https://spotme-app-api.herokuapp.com/api/v1/users/1/gym_memberships
 ```
 
 ### Example Response (Successful)
@@ -302,7 +302,7 @@ Name       | Data Type    | In    | Required/Optional | Description
 ### Example Request
 
 ```
-GET https://spotme-app-api.herokuapp.com/api/v1/users/31/friendships
+GET https://spotme-app-api.herokuapp.com/api/v1/users/1/friendships
 ```
 
 ### Example Response (Successful)


### PR DESCRIPTION
- Changes Implemented:
  - Added PK reset to `seeds` file, so the `/docs` don't have to be continuously updated with any reseed
  - Updated `/docs` to match new endpoint structure (post-removal of `Gyms` table).

- Quality Control Checklist:

  - [x] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
  - [x] 100% SimpleCov test coverage (if below, please clarify below)


- Blockers (if applicable):

- Next Steps & Additional Notes:
  - Reseed db (BE team) and re-record cassettes per new architecture (FE team)
