### PR TITLE
Add new route to find users by google_id

### DIFF
--- a/app/controllers/api/v1/users/find_controller.rb
+++ b/app/controllers/api/v1/users/find_controller.rb
@@ -2,7 +2,9 @@
 # helpers.
 class Api::V1::Users::FindController < ApplicationController
   def index
-    return render json: error_message, status: :not_found if params[:google_id].blank?
+    if params[:google_id].blank?
+      return render json: error_message, status: :not_found
+    end
 
     user = User.find_by!(google_id: params[:google_id])
 
@@ -13,8 +15,8 @@ class Api::V1::Users::FindController < ApplicationController
 
   def error_message
     {
-      message: "your query could not be completed",
-      errors: ["must provide google_id to retrieve user"]
+      message: 'your query could not be completed',
+      errors: ['must provide google_id to retrieve user']
     }
   end
 end

--- a/app/controllers/api/v1/users/find_controller.rb
+++ b/app/controllers/api/v1/users/find_controller.rb
@@ -1,0 +1,20 @@
+# See spec/concerns/response.rb for #json_response and #json_error_response
+# helpers.
+class Api::V1::Users::FindController < ApplicationController
+  def index
+    return render json: error_message, status: :not_found if params[:google_id].blank?
+
+    user = User.find_by!(google_id: params[:google_id])
+
+    render json: UserSerializer.new(user).serializable_hash, status: :ok
+  end
+
+  private
+
+  def error_message
+    {
+      message: "your query could not be completed",
+      errors: ["must provide google_id to retrieve user"]
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :gym_search, only: [:index, :show]
+      namespace :users do
+        resources :find, only: [:index]
+      end
+
       resources :users, only: [:show, :update, :create] do
         resources :events, only: [:index], controller: 'users/events'
         resources :friendships, only: [:index, :create, :destroy], controller: 'users/friendships'

--- a/spec/requests/api/v1/users/find/index_request_spec.rb
+++ b/spec/requests/api/v1/users/find/index_request_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+# See spec/support/shared_examples/ for shared examples for tests where
+# `include_examples` is used. See Shared Examples in the RSpec docs for more
+# info:
+#   https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples
+#
+# See spec/support/request_spec_helper.rb for #json and #json_data helpers.
+describe 'Users::Find API', type: :request do
+  describe 'GET /api/v1/users/find' do
+    let!(:user) { create(:user) }
+    let(:user_id) { user.id }
+    let(:bad_user_id) { User.last.id + 1 }
+
+    context 'when the user record exists' do
+      before { get "/api/v1/users/find", params: { google_id: user.google_id } }
+
+      it 'returns the user', :aggregate_failures do
+        expect(json).not_to be_empty
+
+        expect(json_data.size).to eq(3)
+        expect(json_data[:id]).to eq(user_id.to_s)
+      end
+
+      include_examples 'status code 200'
+    end
+
+    context 'when the user record does not exist' do
+      before { get "/api/v1/users/find", params: { google_id: bad_user_id } }
+
+      it 'returns an error message', :aggregate_failures do
+        expect(json).not_to be_empty
+        expect(json.size).to eq(2)
+
+        expect(json[:message]).to eq('your query could not be completed')
+
+        expect(json[:errors]).to be_an Array
+        expect(json[:errors]).to eq(["Couldn't find User"])
+      end
+
+      include_examples 'status code 404'
+    end
+
+    context 'when no params are provided' do
+      before { get "/api/v1/users/find" }
+
+      it 'returns an error message', :aggregate_failures do
+        expect(json).not_to be_empty
+        expect(json.size).to eq(2)
+
+        expect(json[:message]).to eq('your query could not be completed')
+
+        expect(json[:errors]).to be_an Array
+        expect(json[:errors]).to eq(["must provide google_id to retrieve user"])
+      end
+
+      include_examples 'status code 404'
+    end
+  end
+end

--- a/spec/requests/api/v1/users/find/index_request_spec.rb
+++ b/spec/requests/api/v1/users/find/index_request_spec.rb
@@ -13,7 +13,7 @@ describe 'Users::Find API', type: :request do
     let(:bad_user_id) { User.last.id + 1 }
 
     context 'when the user record exists' do
-      before { get "/api/v1/users/find", params: { google_id: user.google_id } }
+      before { get '/api/v1/users/find', params: { google_id: user.google_id } }
 
       it 'returns the user', :aggregate_failures do
         expect(json).not_to be_empty
@@ -26,7 +26,7 @@ describe 'Users::Find API', type: :request do
     end
 
     context 'when the user record does not exist' do
-      before { get "/api/v1/users/find", params: { google_id: bad_user_id } }
+      before { get '/api/v1/users/find', params: { google_id: bad_user_id } }
 
       it 'returns an error message', :aggregate_failures do
         expect(json).not_to be_empty
@@ -42,7 +42,7 @@ describe 'Users::Find API', type: :request do
     end
 
     context 'when no params are provided' do
-      before { get "/api/v1/users/find" }
+      before { get '/api/v1/users/find' }
 
       it 'returns an error message', :aggregate_failures do
         expect(json).not_to be_empty


### PR DESCRIPTION
- Changes Implemented:
  - Added new route to find users by `google_id` (we were originally going to try to have our FE service call the GET `users/:id` endpoint, which would never return a user based on their google id (essentially making auth impossible, and any actions that call the BE for the `current_user` method, for that matter)

- Quality Control Checklist:

  - [x] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
  - [x] 100% SimpleCov test coverage (if below, please clarify below)
    - Guard clause in the new route makes the line too long, may try to refactor while this is being reviewed, but if not enough time, can come back to later.


- Blockers (if applicable):

- Next Steps & Additional Notes:
  - Open PR from FE repo, so we can re-record cassettes and auth in as users for the final sprint
