### PR TITLE
5 get gym member users endpoint

### DIFF
--- a/app/controllers/api/v1/gym_memberships/users_controller.rb
+++ b/app/controllers/api/v1/gym_memberships/users_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::GymMemberships::UsersController < ApplicationController
+  def index
+    return error_message if params[:yelp_gym_id].blank?
+
+    users = User.users_at_same_gym(params[:yelp_gym_id])
+    options = {}
+    options[:meta] = { gym_member_count: users.size }
+    render json: UserSerializer.new(users, options).serializable_hash,
+           status: :ok
+  end
+
+  def error_message
+    render(
+      json: {
+        message: 'your query could not be completed',
+        errors: ['must provide yelp_gym_id to retrieve members at this gym']
+      },
+      status: :not_found
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      namespace :gym_memberships do
+        resources :users, only: [:index]
+      end
+
       resources :gym_search, only: [:index, :show]
+
       namespace :users do
         resources :find, only: [:index]
       end
@@ -16,7 +21,6 @@ Rails.application.routes.draw do
           resources :events, only: [:create, :destroy], controller: 'users/gym_memberships/events'
         end
       end
-
     end
   end
 end

--- a/spec/requests/api/v1/gym_memberships/users/index_request_spec.rb
+++ b/spec/requests/api/v1/gym_memberships/users/index_request_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+# See spec/support/shared_examples/ for shared examples for tests where
+# `include_examples` is used. See Shared Examples in the RSpec docs for more
+# info:
+#   https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples
+#
+# See spec/support/request_spec_helper.rb for #json and #json_data helpers.
+describe 'GymMemberships::Users API', type: :request do
+  describe 'GET /api/v1/gym_memberships/users' do
+    context 'when there are users that belong to a given gym' do
+      # See spec/factories/users.rb for #experienced_user test setup method
+      experienced_user
+
+      context 'when I do not provide query params' do
+        before { get '/api/v1/gym_memberships/users' }
+
+        it 'returns an error message', :aggregate_failures do
+          expect(json).not_to be_empty
+          expect(json.size).to eq(2)
+
+          expect(json[:message]).to eq('your query could not be completed')
+
+          expect(json[:errors]).to be_an Array
+          expect(json[:errors]).to eq(['must provide yelp_gym_id to retrieve members at this gym'])
+        end
+
+        include_examples 'status code 404'
+      end
+
+      context 'when I provide yelp_gym_id in query params' do
+        let(:gym1_members) { [user1, user2, user3, user5] }
+
+        before { get '/api/v1/gym_memberships/users', params: { yelp_gym_id: gym1 } }
+
+        it 'returns the users that are members of the given gym', :aggregate_failures do
+          expect(json).not_to be_empty
+          require "pry"; binding.pry
+          expect(json[:meta][:gym_member_count]).to eq(4)
+          expect(json_data.size).to eq(4)
+
+          expect(json_data.first[:id]).to eq(user1.id.to_s)
+          expect(json_data.second[:id]).to eq(user2.id.to_s)
+          expect(json_data.third[:id]).to eq(user3.id.to_s)
+          expect(json_data.fourth[:id]).to eq(user5.id.to_s)
+        end
+
+        include_examples 'status code 200'
+      end
+    end
+
+    context 'when there are no users that belong to a given gym' do
+      before { get '/api/v1/gym_memberships/users', params: { yelp_gym_id: 'c2jzsndq84rvn9fbckeec2' } }
+
+      include_examples 'returns nil data'
+      include_examples 'status code 200'
+    end
+  end
+end

--- a/spec/requests/api/v1/gym_memberships/users/index_request_spec.rb
+++ b/spec/requests/api/v1/gym_memberships/users/index_request_spec.rb
@@ -35,7 +35,6 @@ describe 'GymMemberships::Users API', type: :request do
 
         it 'returns the users that are members of the given gym', :aggregate_failures do
           expect(json).not_to be_empty
-          require "pry"; binding.pry
           expect(json[:meta][:gym_member_count]).to eq(4)
           expect(json_data.size).to eq(4)
 


### PR DESCRIPTION
- Changes Implemented:
  - #53 
    - Included the `gym_member_count` in `json_hash[:meta][:gym_member_count]`

- Quality Control Checklist:
  - [X] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
  - [X] 100% SimpleCov test coverage (if below, please clarify below)
  - [X] Last Commit passes Travis build

- Blockers (if applicable):

- Next Steps & Additional Notes:
