### PR TITLE
Endpoint updates tv 10.2

### DIFF
--- a/app/controllers/api/v1/users/friendships_controller.rb
+++ b/app/controllers/api/v1/users/friendships_controller.rb
@@ -5,17 +5,18 @@
 class Api::V1::Users::FriendshipsController < ApplicationController
   def index
     user = User.find(params[:user_id])
-    friends = #if params[:relationship] == 'followers'
+    friends = if params[:relationship] == 'followers'
                 if params[:yelp_gym_id]
-              # if params[:relationship] == 'followee'
-                # user.followees (current user.friends_at_same_gym method call )
-              # elsif params[:relationship] == 'follower'
-                # user.followers (new method call, pending)
-              # end
-                user.followees_at_same_gym(params[:yelp_gym_id])
+                  user.followers_at_same_gym(params[:yelp_gym_id])
+                else
+                  user.followers
+                end
               else
-                # follow same conditional flow as above, independent of GymMembership
-                user.followees
+                if params[:yelp_gym_id]
+                  user.followees_at_same_gym(params[:yelp_gym_id])
+                else
+                  user.followees
+                end
               end
 
     render json: UserSerializer.new(friends).serializable_hash, status: :ok

--- a/app/controllers/api/v1/users/friendships_controller.rb
+++ b/app/controllers/api/v1/users/friendships_controller.rb
@@ -6,17 +6,9 @@ class Api::V1::Users::FriendshipsController < ApplicationController
   def index
     user = User.find(params[:user_id])
     friends = if params[:relationship] == 'followers'
-                if params[:yelp_gym_id]
-                  user.followers_at_same_gym(params[:yelp_gym_id])
-                else
-                  user.followers
-                end
+                params[:yelp_gym_id].present? ? user.followers_at_same_gym(params[:yelp_gym_id]) : user.followers
               else
-                if params[:yelp_gym_id]
-                  user.followees_at_same_gym(params[:yelp_gym_id])
-                else
-                  user.followees
-                end
+                params[:yelp_gym_id].present? ? user.followees_at_same_gym(params[:yelp_gym_id]) : user.followees
               end
 
     render json: UserSerializer.new(friends).serializable_hash, status: :ok

--- a/app/controllers/api/v1/users/friendships_controller.rb
+++ b/app/controllers/api/v1/users/friendships_controller.rb
@@ -5,13 +5,14 @@
 class Api::V1::Users::FriendshipsController < ApplicationController
   def index
     user = User.find(params[:user_id])
-    friends = if params[:yelp_gym_id]
+    friends = #if params[:relationship] == 'followers'
+                if params[:yelp_gym_id]
               # if params[:relationship] == 'followee'
                 # user.followees (current user.friends_at_same_gym method call )
               # elsif params[:relationship] == 'follower'
                 # user.followers (new method call, pending)
               # end
-                user.friends_at_same_gym(params[:yelp_gym_id])
+                user.followees_at_same_gym(params[:yelp_gym_id])
               else
                 # follow same conditional flow as above, independent of GymMembership
                 user.followees

--- a/app/controllers/api/v1/users/gym_members_controller.rb
+++ b/app/controllers/api/v1/users/gym_members_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Users::GymMembersController < ApplicationController
     return error_message if params[:yelp_gym_id].blank?
 
     user = User.find(params[:user_id])
-    users = user.non_friends_at_same_gym(params[:yelp_gym_id])
+    users = user.non_followees_at_same_gym(params[:yelp_gym_id])
 
     render json: UserSerializer.new(users).serializable_hash, status: :ok
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,14 @@ class Event < ApplicationRecord
     user.full_name
   end
 
+  def gym_name
+    gym_membership.gym_name
+  end
+
+  def yelp_gym_id
+    gym_membership.yelp_gym_id
+  end
+
   def self.upcoming_events
     where('date_time >= ?', Time.zone.now).order(date_time: :asc)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ApplicationRecord
   end
 
   def self.upcoming_events
-    where('date_time >= ?', Time.zone.now).order(date_time: :desc)
+    where('date_time >= ?', Time.zone.now).order(date_time: :asc)
   end
 
   def self.past_events

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,9 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :gym_membership
 
+  delegate :gym_name, to: :gym_membership
+  delegate :yelp_gym_id, to: :gym_membership
+
   validates :user_id, presence: true, numericality: true
   validates :gym_membership_id, presence: true, numericality: true
   validates :date_time, presence: true
@@ -13,14 +16,6 @@ class Event < ApplicationRecord
 
   def invited_name
     user.full_name
-  end
-
-  def gym_name
-    gym_membership.gym_name
-  end
-
-  def yelp_gym_id
-    gym_membership.yelp_gym_id
   end
 
   def self.upcoming_events

--- a/app/models/gym_membership.rb
+++ b/app/models/gym_membership.rb
@@ -6,4 +6,16 @@ class GymMembership < ApplicationRecord
   validates :user_id, presence: true, numericality: true
   validates :yelp_gym_id, presence: true
   validates :gym_name, presence: true
+
+  def find_gym
+    GymFacade.find_gym(yelp_gym_id)
+  end
+
+  def address
+    find_gym.address
+  end
+
+  def address_details
+    find_gym.address_details
+  end
 end

--- a/app/models/gym_membership.rb
+++ b/app/models/gym_membership.rb
@@ -3,19 +3,14 @@ class GymMembership < ApplicationRecord
 
   has_many :events, dependent: :destroy
 
+  delegate :address, to: :find_gym
+  delegate :address_details, to: :find_gym
+
   validates :user_id, presence: true, numericality: true
   validates :yelp_gym_id, presence: true
   validates :gym_name, presence: true
 
   def find_gym
     GymFacade.find_gym(yelp_gym_id)
-  end
-
-  def address
-    find_gym.address
-  end
-
-  def address_details
-    find_gym.address_details
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,13 +37,27 @@ class User < ApplicationRecord
     hosted_past_events + invited_past_events
   end
 
-  def friends_at_same_gym(yelp_gym_id)
+  def followees_at_same_gym(yelp_gym_id)
+    # users that the current user IS following at the same gym
     followees.users_at_same_gym(yelp_gym_id)
   end
 
-  def non_friends_at_same_gym(yelp_gym_id)
+  def followers_at_same_gym(yelp_gym_id)
+    # users that are following the current user at the same gym
+    followers.users_at_same_gym(yelp_gym_id)
+  end
+
+  def non_followees_at_same_gym(yelp_gym_id)
+    # users that the current user is NOT following at the same gym
     User.users_at_same_gym(yelp_gym_id) -
-      friends_at_same_gym(yelp_gym_id) -
+      followees_at_same_gym(yelp_gym_id) -
+      [self]
+  end
+
+  def non_followers_at_same_gym(yelp_gym_id)
+    # users that are not following the current user at the same gym
+    User.users_at_same_gym(yelp_gym_id) -
+      followers_at_same_gym(yelp_gym_id) -
       [self]
   end
 

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -6,7 +6,9 @@ class EventSerializer
   meta do |event, params|
     {
       friend_name: params[:current_user] == event.user_id.to_s ? event.host_name : event.invited_name,
-      friend_role: params[:current_user] == event.user_id.to_s ? 'host' : 'invited'
+      friend_role: params[:current_user] == event.user_id.to_s ? 'host' : 'invited',
+      gym_name: event.gym_name,
+      yelp_gym_id: event.yelp_gym_id
     }
   end
 end

--- a/app/serializers/gym_membership_serializer.rb
+++ b/app/serializers/gym_membership_serializer.rb
@@ -2,4 +2,11 @@ class GymMembershipSerializer
   include JSONAPI::Serializer
 
   attributes :user_id, :yelp_gym_id, :gym_name
+
+  meta do |gym_membership|
+    {
+      address: gym_membership.address,
+      address_details: gym_membership.address_details
+    }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,6 +31,7 @@ def experienced_user
   let!(:ff1_4) { create(:friendship, follower_id: user1.id, followee_id: user4.id) }
   let!(:ff1_5) { create(:friendship, follower_id: user1.id, followee_id: user5.id) }
   let!(:ff1_6) { create(:friendship, follower_id: user1.id, followee_id: user6.id) }
+  let!(:ff2_1) { create(:friendship, follower_id: user2.id, followee_id: user1.id) }
 
   let!(:gym1) { 'mkmn8pidmebehvh79u1ovg' }
   let!(:gym2) { 'fvdr0ksvy2nhith42ffur2' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -33,9 +33,10 @@ def experienced_user
   let!(:ff1_6) { create(:friendship, follower_id: user1.id, followee_id: user6.id) }
   let!(:ff2_1) { create(:friendship, follower_id: user2.id, followee_id: user1.id) }
 
-  let!(:gym1) { 'mkmn8pidmebehvh79u1ovg' }
-  let!(:gym2) { 'fvdr0ksvy2nhith42ffur2' }
-  let!(:gym3) { 'j30b22smeauhacmvx4sfgh' }
+  # Note, real yelp_gym_ids for gym_membership.address and gym_membership.address_details method calls
+  let!(:gym1) { 'gHmS3WIjRRhSWG4OdCQYLA' }
+  let!(:gym2) { 'yQaElwKOFU865x1jxH3KGw' }
+  let!(:gym3) { '77ZmLGWFlgXoGie_p22wvQ' }
 
   # Gym Member variable naming convention:
   #   gym_mem<user>_<gym>

--- a/spec/fixtures/vcr_cassettes/GymMembership/instance_methods/_address_and_address_details/can_return_the_address_and_address_details_of_the_gym_membership.yml
+++ b/spec/fixtures/vcr_cassettes/GymMembership/instance_methods/_address_and_address_details/can_return_the_address_and_address_details_of_the_gym_membership.yml
@@ -1,0 +1,258 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Remaining:
+      - '4979'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-bgmkh; site=public_api_v3
+      X-Zipkin-Id:
+      - 4ef75d5f731c7c85
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-173-40-uswest2bprod
+      X-Extlb:
+      - 10-69-173-40-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:02:54 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10640-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:02:54 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - 0550a69018bc2aa9
+      Ratelimit-Remaining:
+      - '4978'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-126-17-uswest2aprod
+      X-Extlb:
+      - 10-69-126-17-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:02:54 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10671-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:02:54 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-B3-Sampled:
+      - '0'
+      Server:
+      - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-64kj6; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - 3d0a622fc7942398
+      Ratelimit-Remaining:
+      - '4977'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-105-191-uswest2aprod
+      X-Extlb:
+      - 10-69-105-191-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:02:54 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10669-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:02:54 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymMembership/instance_methods/_address_and_address_details/can_return_the_address_of_the_gym_membership.yml
+++ b/spec/fixtures/vcr_cassettes/GymMembership/instance_methods/_address_and_address_details/can_return_the_address_of_the_gym_membership.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      Server:
+      - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-g7dkv; site=public_api_v3
+      Ratelimit-Remaining:
+      - '4997'
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - c5ecb4927902ae7d
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-113-185-uswest2aprod
+      X-Extlb:
+      - 10-69-113-185-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:00:15 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10743-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:00:15 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-trfl5; site=public_api_v3
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 70409b96dd9d819c
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Ratelimit-Remaining:
+      - '4996'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-173-40-uswest2bprod
+      X-Extlb:
+      - 10-69-173-40-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:00:15 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10739-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:00:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymMembershipSerializer/instance_methods/_serializable_hash/when_I_provide_a_valid_gym_membership/formats_the_single_gym_membership_response_for_delivery.yml
+++ b/spec/fixtures/vcr_cassettes/GymMembershipSerializer/instance_methods/_serializable_hash/when_I_provide_a_valid_gym_membership/formats_the_single_gym_membership_response_for_delivery.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
-      X-B3-Sampled:
-      - '0'
-      Server:
-      - envoy
       X-Routing-Service:
       - routing-main--uswest2-7b96896cd8-g7dkv; site=public_api_v3
-      Ratelimit-Remaining:
-      - '4997'
+      X-Zipkin-Id:
+      - fc5212443a936ccd
       Ratelimit-Dailylimit:
       - '5000'
-      X-Zipkin-Id:
-      - c5ecb4927902ae7d
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
+      Ratelimit-Remaining:
+      - '4774'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:15 GMT
+      - Sun, 03 Oct 2021 04:46:40 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10743-LGB
+      - cache-bur17525-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,7 +84,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:00:15 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:40 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -109,36 +109,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Dailylimit:
-      - '5000'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-trfl5; site=public_api_v3
       Server:
       - envoy
       X-B3-Sampled:
       - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-75zpx; site=public_api_v3
       X-Zipkin-Id:
-      - 70409b96dd9d819c
+      - 936dac36e66e3b07
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4773'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      Ratelimit-Remaining:
-      - '4996'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:15 GMT
+      - Sun, 03 Oct 2021 04:46:41 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10739-LGB
+      - cache-sna10732-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -169,5 +169,90 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:00:15 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:41 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gx6zl; site=public_api_v3
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - ba9f1d6316476423
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4772'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-69-73-uswest2aprod
+      X-Extlb:
+      - 10-69-69-73-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:41 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10627-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:41 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_an_error_code_404.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_an_error_code_404.yml
@@ -26,28 +26,28 @@ http_interactions:
       - '102'
       Content-Type:
       - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-m27xt; site=public_api_v3
       Server:
       - envoy
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-6z852; site=public_api_v3
       X-B3-Sampled:
       - '0'
       X-Zipkin-Id:
-      - 9adf53a4d521792f
+      - 3108488bf5701375
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-130-205-uswest2bprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-130-205-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:00 GMT
+      - Sun, 03 Oct 2021 04:00:20 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8243-DEN
+      - cache-bur17566-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:00 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_an_error_code_404.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_an_error_code_404.yml
@@ -27,27 +27,27 @@ http_interactions:
       Content-Type:
       - application/json
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-m27xt; site=public_api_v3
-      Server:
-      - envoy
+      - routing-main--uswest2-7b96896cd8-gx6zl; site=public_api_v3
       X-B3-Sampled:
       - '0'
       X-Zipkin-Id:
-      - 3108488bf5701375
+      - b6edbca672732c08
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:20 GMT
+      - Sun, 03 Oct 2021 04:46:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-bur17566-BUR
+      - cache-lax10643-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_status_code_404_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_status_code_404_not_found.yml
@@ -26,28 +26,28 @@ http_interactions:
       - '102'
       Content-Type:
       - application/json
-      Server:
-      - envoy
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-dg5zz; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
       X-B3-Sampled:
       - '0'
       X-Zipkin-Id:
-      - eefe6a139abbb5f9
+      - 99a24fd4f364c0e7
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       X-Extlb:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:00 GMT
+      - Sun, 03 Oct 2021 04:00:20 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8256-DEN
+      - cache-lax10645-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:00 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_status_code_404_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_but_unfound_yelp_gym_id_is_given/returns_status_code_404_not_found.yml
@@ -26,28 +26,28 @@ http_interactions:
       - '102'
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
       X-B3-Sampled:
       - '0'
       X-Zipkin-Id:
-      - 99a24fd4f364c0e7
+      - b884938174c952f2
       Server:
       - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-shc9c; site=public_api_v3
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:20 GMT
+      - Sun, 03 Oct 2021 04:46:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10645-LGB
+      - cache-bur17560-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_a_gym.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_a_gym.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Zipkin-Id:
-      - f330c25efdf3871d
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-m27xt; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
-      Ratelimit-Remaining:
-      - '4989'
       Server:
       - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4802'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-h4s2c; site=public_api_v3
+      X-Zipkin-Id:
+      - 33176753212fda27
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:20 GMT
+      - Sun, 03 Oct 2021 04:46:27 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10721-LGB
+      - cache-sna10750-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,5 +84,5 @@ http_interactions:
         "0600", "end": "2000", "day": 5}, {"is_overnight": false, "start": "0600",
         "end": "2000", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}],
         "transactions": []}'
-  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_a_gym.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_a_gym.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Dailylimit:
-      - '5000'
       X-Zipkin-Id:
-      - eac6cea80c4e1745
-      Ratelimit-Remaining:
-      - '4982'
+      - f330c25efdf3871d
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-rxtpv; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-m27xt; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Ratelimit-Remaining:
+      - '4989'
       Server:
       - envoy
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:59 GMT
+      - Sun, 03 Oct 2021 04:00:20 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8271-DEN
+      - cache-sna10721-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,5 +84,5 @@ http_interactions:
         "0600", "end": "2000", "day": 5}, {"is_overnight": false, "start": "0600",
         "end": "2000", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}],
         "transactions": []}'
-  recorded_at: Fri, 01 Oct 2021 05:54:59 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Remaining:
-      - '4988'
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-shc9c; site=public_api_v3
+      X-Zipkin-Id:
+      - 5586ffc29303c8ff
       X-B3-Sampled:
       - '0'
-      X-Zipkin-Id:
-      - '0728b99d7c721888'
-      Server:
-      - envoy
+      Ratelimit-Remaining:
+      - '4801'
       Ratelimit-Dailylimit:
       - '5000'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:20 GMT
+      - Sun, 03 Oct 2021 04:46:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10676-LGB
+      - cache-bur17571-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,5 +84,5 @@ http_interactions:
         "0600", "end": "2000", "day": 5}, {"is_overnight": false, "start": "0600",
         "end": "2000", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}],
         "transactions": []}'
-  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/_id/when_a_valid_yelp_gym_id_is_given/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      Ratelimit-Remaining:
+      - '4988'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      X-Zipkin-Id:
+      - '0728b99d7c721888'
       Server:
       - envoy
       Ratelimit-Dailylimit:
       - '5000'
-      Ratelimit-Remaining:
-      - '4981'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-vctt6; site=public_api_v3
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
-      X-Zipkin-Id:
-      - a99e0371ca93d7f3
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:59 GMT
+      - Sun, 03 Oct 2021 04:00:20 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8259-DEN
+      - cache-lax10676-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,5 +84,5 @@ http_interactions:
         "0600", "end": "2000", "day": 5}, {"is_overnight": false, "start": "0600",
         "end": "2000", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}],
         "transactions": []}'
-  recorded_at: Fri, 01 Oct 2021 05:54:59 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
-      Server:
-      - envoy
-      X-Zipkin-Id:
-      - e53ea605ae7ece96
-      Ratelimit-Dailylimit:
-      - '5000'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
       Ratelimit-Remaining:
-      - '4984'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-g8p9d; site=public_api_v3
+      - '4991'
+      X-Zipkin-Id:
+      - 5a107e57c7c80266
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-108-234-uswest2aprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-108-234-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:58 GMT
+      - Sun, 03 Oct 2021 04:00:19 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8256-DEN
+      - cache-sna10747-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:58 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Remaining:
-      - '4991'
-      X-Zipkin-Id:
-      - 5a107e57c7c80266
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
       Server:
       - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-g7dkv; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - 8f2a81550d1675fd
+      Ratelimit-Remaining:
+      - '4804'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-108-234-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-108-234-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:19 GMT
+      - Sun, 03 Oct 2021 04:46:27 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10747-LGB
+      - cache-sna10750-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2blvg; site=public_api_v3
-      Ratelimit-Dailylimit:
-      - '5000'
       Ratelimit-Remaining:
-      - '4983'
-      Server:
-      - envoy
+      - '4990'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 58ddc50c08e857e2
       X-B3-Sampled:
       - '0'
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
-      X-Zipkin-Id:
-      - 0c27ba16c4c7c06e
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:58 GMT
+      - Sun, 03 Oct 2021 04:00:19 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8238-DEN
+      - cache-lax10625-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:59 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_but_0_gyms_are_nearby/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Remaining:
-      - '4990'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - 58ddc50c08e857e2
       X-B3-Sampled:
       - '0'
       Server:
       - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-75zpx; site=public_api_v3
+      X-Zipkin-Id:
+      - c1d6b0c969b7c8f6
       Ratelimit-Dailylimit:
       - '5000'
+      Ratelimit-Remaining:
+      - '4803'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-105-191-uswest2aprod
+      - 10-69-130-205-uswest2bprod
       X-Extlb:
-      - 10-69-105-191-uswest2aprod
+      - 10-69-130-205-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:19 GMT
+      - Sun, 03 Oct 2021 04:46:27 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10625-LGB
+      - cache-bur17577-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-64kj6; site=public_api_v3
-      Server:
-      - envoy
-      X-Zipkin-Id:
-      - abe53dbed216bf36
-      Ratelimit-Dailylimit:
-      - '5000'
+      - routing-main--uswest2-7b96896cd8-dcrwj; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
       Ratelimit-Remaining:
-      - '4995'
+      - '4808'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - ae5102aa6d73b3da
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
@@ -49,11 +49,11 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:17 GMT
+      - Sun, 03 Oct 2021 04:46:25 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10654-LGB
+      - cache-bur17580-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:17 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:25 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -24,20 +24,20 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-64kj6; site=public_api_v3
       Server:
       - envoy
-      X-B3-Sampled:
-      - '0'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-dg5zz; site=public_api_v3
+      X-Zipkin-Id:
+      - abe53dbed216bf36
       Ratelimit-Dailylimit:
       - '5000'
+      X-B3-Sampled:
+      - '0'
       Ratelimit-Remaining:
-      - '4988'
-      X-Zipkin-Id:
-      - f2336f30bf161dbb
+      - '4995'
       Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
+      - '2021-10-04T00:00:00+00:00'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
@@ -49,11 +49,11 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:55 GMT
+      - Sun, 03 Oct 2021 04:00:17 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8229-DEN
+      - cache-lax10654-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -75,7 +75,7 @@ http_interactions:
         "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
         FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
         2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
-        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
         "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
         "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
         "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:55 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:17 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-tdjtx; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-q6r44; site=public_api_v3
       X-B3-Sampled:
       - '0'
-      Server:
-      - envoy
+      X-Zipkin-Id:
+      - 33aa0568d9701d70
+      Ratelimit-Remaining:
+      - '4807'
       Ratelimit-Dailylimit:
       - '5000'
-      Ratelimit-Remaining:
-      - '4994'
-      X-Zipkin-Id:
-      - 8469b3adb5522c66
+      Server:
+      - envoy
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-69-73-uswest2aprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-69-73-uswest2aprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:18 GMT
+      - Sun, 03 Oct 2021 04:46:26 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10727-LGB
+      - cache-sna10723-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:18 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:26 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_a_plethora_of_gyms/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-tdjtx; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
       Server:
       - envoy
-      X-Zipkin-Id:
-      - b902e9ba1c817d61
       Ratelimit-Dailylimit:
       - '5000'
       Ratelimit-Remaining:
-      - '4987'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2smkr; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
+      - '4994'
+      X-Zipkin-Id:
+      - 8469b3adb5522c66
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-69-73-uswest2aprod
       X-Extlb:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-69-73-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:56 GMT
+      - Sun, 03 Oct 2021 04:00:18 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8247-DEN
+      - cache-sna10727-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -75,7 +75,7 @@ http_interactions:
         "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
         FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
         2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
-        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
         "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
         "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
         "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:56 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:18 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Zipkin-Id:
-      - 9c0a9de910559a65
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-bwzdx; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
       Ratelimit-Dailylimit:
       - '5000'
       Ratelimit-Remaining:
-      - '4993'
-      Server:
-      - envoy
+      - '4806'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gx6zl; site=public_api_v3
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 4843643d9dec1491
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:18 GMT
+      - Sun, 03 Oct 2021 04:46:26 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10746-LGB
+      - cache-sna10748-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:18 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:26 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_20_nearby_gyms_sorted_by_distance.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Dailylimit:
-      - '5000'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-cpzgg; site=public_api_v3
       X-Zipkin-Id:
-      - fa65175218d56f57
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
+      - 9c0a9de910559a65
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-bwzdx; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
       Ratelimit-Remaining:
-      - '4986'
+      - '4993'
       Server:
       - envoy
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-130-205-uswest2bprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-130-205-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:57 GMT
+      - Sun, 03 Oct 2021 04:00:18 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8250-DEN
+      - cache-sna10746-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:57 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:18 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Zipkin-Id:
-      - dd987466fc0a1c7f
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Remaining:
-      - '4992'
-      X-B3-Sampled:
-      - '0'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-shc9c; site=public_api_v3
+      X-Zipkin-Id:
+      - d936dd4d9d5496f0
+      Ratelimit-Remaining:
+      - '4805'
+      Ratelimit-Dailylimit:
+      - '5000'
       Server:
       - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-69-73-uswest2aprod
+      - 10-69-173-40-uswest2bprod
       X-Extlb:
-      - 10-69-69-73-uswest2aprod
+      - 10-69-173-40-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:19 GMT
+      - Sun, 03 Oct 2021 04:46:26 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10744-LGB
+      - cache-lax10630-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:26 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/GymSearch_API/GET_/api/v1/gym_search/when_a_valid_location_is_provided_with_less_than_20_available_gyms/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-B3-Sampled:
-      - '0'
+      X-Zipkin-Id:
+      - dd987466fc0a1c7f
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
       Ratelimit-Dailylimit:
       - '5000'
-      X-Zipkin-Id:
-      - 1149657448c88b19
+      Ratelimit-Remaining:
+      - '4992'
+      X-B3-Sampled:
+      - '0'
       Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
+      - '2021-10-04T00:00:00+00:00'
       Server:
       - envoy
-      Ratelimit-Remaining:
-      - '4985'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-g8p9d; site=public_api_v3
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-69-73-uswest2aprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-69-73-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:54:58 GMT
+      - Sun, 03 Oct 2021 04:00:19 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8249-DEN
+      - cache-sna10744-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Fri, 01 Oct 2021 05:54:58 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:19 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_a_valid_yelp_id_is_provided/returns_the_business_information.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_a_valid_yelp_id_is_provided/returns_the_business_information.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-zkv7t; site=public_api_v3
-      Server:
-      - envoy
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Remaining:
-      - '4981'
       X-B3-Sampled:
       - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-shc9c; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Zipkin-Id:
+      - 1e77335c3cfc272d
+      Ratelimit-Remaining:
+      - '4767'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - 3a8f6b248e68605c
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-69-73-uswest2aprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-69-73-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:28 GMT
+      - Sun, 03 Oct 2021 04:46:43 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10654-LGB
+      - cache-sna10727-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -82,5 +82,5 @@ http_interactions:
         "1600", "day": 5}, {"is_overnight": false, "start": "0900", "end": "1500",
         "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:43 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_a_valid_yelp_id_is_provided/returns_the_business_information.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_a_valid_yelp_id_is_provided/returns_the_business_information.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Dailylimit:
-      - '5000'
-      X-B3-Sampled:
-      - '0'
-      Ratelimit-Remaining:
-      - '4974'
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
-      X-Zipkin-Id:
-      - bc8d8de5240cdadb
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-rptf5; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-zkv7t; site=public_api_v3
       Server:
       - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4981'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 3a8f6b248e68605c
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       X-Extlb:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:08 GMT
+      - Sun, 03 Oct 2021 04:00:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8263-DEN
+      - cache-lax10654-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -82,5 +82,5 @@ http_interactions:
         "1600", "day": 5}, {"is_overnight": false, "start": "0900", "end": "1500",
         "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Fri, 01 Oct 2021 05:55:08 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_an_invalid_yelp_id_is_provided/returns_an_error_if_the_gym_is_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_an_invalid_yelp_id_is_provided/returns_an_error_if_the_gym_is_not_found.yml
@@ -27,27 +27,27 @@ http_interactions:
       Content-Type:
       - application/json
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-2j5zt; site=public_api_v3
-      X-Zipkin-Id:
-      - 3d06d24ba544cd29
+      - routing-main--uswest2-7b96896cd8-m27xt; site=public_api_v3
       Server:
       - envoy
       X-B3-Sampled:
       - '0'
+      X-Zipkin-Id:
+      - 19a51fabd0efdc88
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       X-Extlb:
-      - 10-69-185-39-uswest2bprod
+      - 10-69-152-12-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:28 GMT
+      - Sun, 03 Oct 2021 04:46:43 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10641-LGB
+      - cache-bur17554-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:43 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_an_invalid_yelp_id_is_provided/returns_an_error_if_the_gym_is_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_find_gym/when_an_invalid_yelp_id_is_provided/returns_an_error_if_the_gym_is_not_found.yml
@@ -27,9 +27,9 @@ http_interactions:
       Content-Type:
       - application/json
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-5pch9; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-2j5zt; site=public_api_v3
       X-Zipkin-Id:
-      - b5f01d0fc308d28d
+      - 3d06d24ba544cd29
       Server:
       - envoy
       X-B3-Sampled:
@@ -43,11 +43,11 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:08 GMT
+      - Sun, 03 Oct 2021 04:00:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8244-DEN
+      - cache-lax10641-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "BUSINESS_NOT_FOUND", "description": "The requested
         business could not be found."}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:08 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Remaining:
-      - '4983'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-bgmkh; site=public_api_v3
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
       Server:
       - envoy
-      X-Zipkin-Id:
-      - 1a1499d0edb10935
       X-B3-Sampled:
       - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 60a8c9a445beff05
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-wdbvd; site=public_api_v3
+      Ratelimit-Remaining:
+      - '4769'
+      Ratelimit-Dailylimit:
+      - '5000'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:27 GMT
+      - Sun, 03 Oct 2021 04:46:42 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10636-LGB
+      - cache-bur17542-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:27 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:42 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_0_gyms_nearby/retrieves_an_empty_dataset_not_an_error.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Remaining:
-      - '4976'
-      X-Zipkin-Id:
-      - f330c97e320218a5
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
-      X-B3-Sampled:
-      - '0'
-      Server:
-      - envoy
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-rxtpv; site=public_api_v3
       Ratelimit-Dailylimit:
       - '5000'
+      Ratelimit-Remaining:
+      - '4983'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-bgmkh; site=public_api_v3
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
+      X-Zipkin-Id:
+      - 1a1499d0edb10935
+      X-B3-Sampled:
+      - '0'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-152-12-uswest2bprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-152-12-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:07 GMT
+      - Sun, 03 Oct 2021 04:00:27 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8266-DEN
+      - cache-lax10636-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -66,5 +66,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"businesses": [], "total": 0, "region": {"center": {"longitude": -119.432373046875,
         "latitude": 40.4462157989704}}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:07 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
@@ -27,27 +27,27 @@ http_interactions:
       Content-Type:
       - application/json
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-q6r44; site=public_api_v3
-      X-Zipkin-Id:
-      - 9ad76077245e1e44
-      Server:
-      - envoy
+      - routing-main--uswest2-7b96896cd8-pxc98; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      X-Zipkin-Id:
+      - 1a754ebf9de37f1c
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       X-Extlb:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:28 GMT
+      - Sun, 03 Oct 2021 04:46:42 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10657-LGB
+      - cache-sna10728-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "LOCATION_NOT_FOUND", "description": "Could not
         execute search, try specifying a more exact location."}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:42 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_bad_zip_code_is_queried/returns_an_error_if_the_location_provided_is_not_found.yml
@@ -26,28 +26,28 @@ http_interactions:
       - '123'
       Content-Type:
       - application/json
-      X-B3-Sampled:
-      - '0'
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-rptf5; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-q6r44; site=public_api_v3
       X-Zipkin-Id:
-      - 5944a5ea72de78d3
+      - 9ad76077245e1e44
       Server:
       - envoy
+      X-B3-Sampled:
+      - '0'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:07 GMT
+      - Sun, 03 Oct 2021 04:00:28 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8253-DEN
+      - cache-lax10657-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"error": {"code": "LOCATION_NOT_FOUND", "description": "Could not
         execute search, try specifying a more exact location."}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:07 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:28 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Server:
-      - envoy
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-882tq; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
+      X-Zipkin-Id:
+      - 3a3368863c1e8cf3
       Ratelimit-Dailylimit:
       - '5000'
-      X-Zipkin-Id:
-      - d7afc26c8ce88637
       Ratelimit-Remaining:
-      - '4977'
+      - '4984'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-bwzdx; site=public_api_v3
       Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
+      - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-173-40-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:06 GMT
+      - Sun, 03 Oct 2021 04:00:27 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8253-DEN
+      - cache-bur17581-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:06 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_less_than_20_gyms_nearby_but_more_than_0/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Zipkin-Id:
-      - 3a3368863c1e8cf3
-      Ratelimit-Dailylimit:
-      - '5000'
-      Ratelimit-Remaining:
-      - '4984'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-bwzdx; site=public_api_v3
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 2a3b00d169c6ff31
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gq6gs; site=public_api_v3
       X-B3-Sampled:
       - '0'
       Server:
       - envoy
+      Ratelimit-Remaining:
+      - '4770'
+      Ratelimit-Dailylimit:
+      - '5000'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       X-Extlb:
-      - 10-69-184-36-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:27 GMT
+      - Sun, 03 Oct 2021 04:46:42 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-bur17581-BUR
+      - cache-lax10624-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -216,5 +216,5 @@ http_interactions:
         "+12073384598", "display_phone": "(207) 338-4598", "distance": 43655.58741866142}],
         "total": 16, "region": {"center": {"longitude": -69.36630249023438, "latitude":
         44.10811081310502}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:27 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:42 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Zipkin-Id:
-      - 73ddf023f2ca6a2a
-      Ratelimit-Dailylimit:
-      - '5000'
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-gz76z; site=public_api_v3
-      Ratelimit-Remaining:
-      - '4978'
-      Server:
-      - envoy
-      Ratelimit-Resettime:
-      - '2021-10-02T00:00:00+00:00'
       X-B3-Sampled:
       - '0'
+      Ratelimit-Remaining:
+      - '4985'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-h4s2c; site=public_api_v3
+      X-Zipkin-Id:
+      - b2a7b4208ce24fd8
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-152-12-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 01 Oct 2021 05:55:05 GMT
+      - Sun, 03 Oct 2021 04:00:26 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-den8234-DEN
+      - cache-sna10727-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -75,7 +75,7 @@ http_interactions:
         "US", "state": "FL", "display_address": ["1817 San Marco Rd", "Marco Island,
         FL 34145"]}, "phone": "+12393949235", "display_phone": "(239) 394-9235", "distance":
         2580.2116310113224}, {"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
-        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
         "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=awGBNkM_j8pKscZth2VNGA",
         "review_count": 10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias":
         "massage", "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}],
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Fri, 01 Oct 2021 05:55:05 GMT
+  recorded_at: Sun, 03 Oct 2021 04:00:26 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
+++ b/spec/fixtures/vcr_cassettes/GymService/class_methods/_gyms_near_user/when_more_than_20_gyms_nearby/retrieves_the_20_closest_gyms_from_Yelp_within_40k_meters_of_the_user_s_location.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-B3-Sampled:
-      - '0'
       Ratelimit-Remaining:
-      - '4985'
+      - '4771'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-h4s2c; site=public_api_v3
-      X-Zipkin-Id:
-      - b2a7b4208ce24fd8
-      Ratelimit-Dailylimit:
-      - '5000'
+      - routing-main--uswest2-7b96896cd8-q6r44; site=public_api_v3
       Server:
       - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 652ef50d117a2e0d
+      Ratelimit-Dailylimit:
+      - '5000'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-126-17-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:00:26 GMT
+      - Sun, 03 Oct 2021 04:46:41 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-sna10727-LGB
+      - cache-bur17535-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -261,5 +261,5 @@ http_interactions:
         "phone": "+12393316915", "display_phone": "(239) 331-6915", "distance": 26708.835300594896}],
         "total": 114, "region": {"center": {"longitude": -81.69708251953125, "latitude":
         25.91046095897436}}}'
-  recorded_at: Sun, 03 Oct 2021 04:00:26 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:41 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberhips_API/GET_/api/v1/users/_id/gym_memberships/when_the_user_gym_membership_records_exists/returns_status_code_200_ok.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberhips_API/GET_/api/v1/users/_id/gym_memberships/when_the_user_gym_membership_records_exists/returns_status_code_200_ok.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-dc8nb; site=public_api_v3
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      Server:
-      - envoy
       X-B3-Sampled:
       - '0'
-      X-Zipkin-Id:
-      - 6311ceb48007003c
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-8fpx7; site=public_api_v3
       Ratelimit-Dailylimit:
       - '5000'
+      Server:
+      - envoy
       Ratelimit-Remaining:
-      - '4811'
+      - '4778'
+      X-Zipkin-Id:
+      - b5f2e8a0a53c8423
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       X-Extlb:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-185-39-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:38 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-bur17526-BUR
+      - cache-bur17540-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,7 +84,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:38 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -110,15 +110,15 @@ http_interactions:
       Content-Type:
       - application/json
       Ratelimit-Remaining:
-      - '4810'
+      - '4777'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - 1fc956b9229b7535
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-2qlg8; site=public_api_v3
       X-B3-Sampled:
       - '0'
+      X-Zipkin-Id:
+      - 4697f4697da77d4f
       Server:
       - envoy
       Ratelimit-Dailylimit:
@@ -126,19 +126,19 @@ http_interactions:
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:38 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-sna10751-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -169,10 +169,10 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:38 GMT
 - request:
     method: get
-    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
     body:
       encoding: US-ASCII
       string: ''
@@ -194,36 +194,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      X-Zipkin-Id:
+      - 9bee93be1c63b362
       Ratelimit-Dailylimit:
       - '5000'
-      X-B3-Sampled:
-      - '0'
-      Ratelimit-Remaining:
-      - '4809'
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - c18e9cfe63c50df8
       Server:
       - envoy
       X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-wdbvd; site=public_api_v3
+      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Ratelimit-Remaining:
+      - '4776'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-184-36-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:38 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-bur17534-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -234,25 +234,110 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
-        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
-        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
-        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
-        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
-        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
-        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
-        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
-        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
-        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
-        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
-        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
-        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
-        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
-        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
-        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
-        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
-        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
-        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
-        []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:38 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-B3-Sampled:
+      - '0'
+      Server:
+      - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-pxc98; site=public_api_v3
+      Ratelimit-Remaining:
+      - '4775'
+      X-Zipkin-Id:
+      - 7e91b83fcf62c408
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-105-191-uswest2aprod
+      X-Extlb:
+      - 10-69-105-191-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:39 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10729-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:39 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberhips_API/GET_/api/v1/users/_id/gym_memberships/when_the_user_gym_membership_records_exists/returns_the_users_gym_memberships.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberhips_API/GET_/api/v1/users/_id/gym_memberships/when_the_user_gym_membership_records_exists/returns_the_users_gym_memberships.yml
@@ -1,0 +1,683 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 8784b55910b9e308
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-dcrwj; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4786'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-184-36-uswest2bprod
+      X-Extlb:
+      - 10-69-184-36-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:36 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10720-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:36 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4785'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 987536fb12f8eea8
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-wdbvd; site=public_api_v3
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-108-234-uswest2aprod
+      X-Extlb:
+      - 10-69-108-234-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:32 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17550-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:36 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-g7dkv; site=public_api_v3
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 07e61ea6eafa7e7d
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Ratelimit-Remaining:
+      - '4784'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-113-185-uswest2aprod
+      X-Extlb:
+      - 10-69-113-185-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:36 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10729-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:36 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Zipkin-Id:
+      - 2b8fb33883ef8770
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-bwzdx; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4783'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-105-191-uswest2aprod
+      X-Extlb:
+      - 10-69-105-191-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:36 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17540-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:36 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2df7g; site=public_api_v3
+      X-Zipkin-Id:
+      - 58693e428d6577fd
+      Ratelimit-Remaining:
+      - '4782'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-173-40-uswest2bprod
+      X-Extlb:
+      - 10-69-173-40-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:37 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17546-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:37 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Zipkin-Id:
+      - 2dcf540db25b1345
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-wgl7j; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Remaining:
+      - '4781'
+      Server:
+      - envoy
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-184-36-uswest2bprod
+      X-Extlb:
+      - 10-69-184-36-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:37 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10642-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:37 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Zipkin-Id:
+      - c62e29e5849ee365
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gq6gs; site=public_api_v3
+      Ratelimit-Remaining:
+      - '4780'
+      Server:
+      - envoy
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-126-17-uswest2aprod
+      X-Extlb:
+      - 10-69-126-17-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:37 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17566-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:37 GMT
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/yQaElwKOFU865x1jxH3KGw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Remaining:
+      - '4779'
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 754d2b875ae8b714
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2j5zt; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-108-234-uswest2aprod
+      X-Extlb:
+      - 10-69-108-234-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:37 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10634-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "yQaElwKOFU865x1jxH3KGw", "alias": "xcel-fitness-spa-marco-island",
+        "name": "Xcel Fitness Spa", "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/xcel-fitness-spa-marco-island?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12393949235", "display_phone": "(239) 394-9235", "review_count":
+        10, "categories": [{"alias": "gyms", "title": "Gyms"}, {"alias": "massage",
+        "title": "Massage"}, {"alias": "healthtrainers", "title": "Trainers"}], "rating":
+        4.0, "location": {"address1": "1817 San Marco Rd", "address2": null, "address3":
+        "", "city": "Marco Island", "zip_code": "34145", "country": "US", "state":
+        "FL", "display_address": ["1817 San Marco Rd", "Marco Island, FL 34145"],
+        "cross_streets": ""}, "coordinates": {"latitude": 25.9341526, "longitude":
+        -81.6989467}, "photos": ["https://s3-media2.fl.yelpcdn.com/bphoto/ccAjpYauX08M1B23wHFE3Q/o.jpg",
+        "https://s3-media2.fl.yelpcdn.com/bphoto/Rx1MuJegPvksWLbH82DmNg/o.jpg", "https://s3-media2.fl.yelpcdn.com/bphoto/Qot7suis2wM54QxFQx1DIg/o.jpg"],
+        "price": "$$$", "hours": [{"open": [{"is_overnight": false, "start": "0900",
+        "end": "1900", "day": 0}, {"is_overnight": false, "start": "0900", "end":
+        "1900", "day": 1}, {"is_overnight": false, "start": "0900", "end": "1900",
+        "day": 2}, {"is_overnight": false, "start": "0900", "end": "1900", "day":
+        3}, {"is_overnight": false, "start": "0900", "end": "1900", "day": 4}, {"is_overnight":
+        false, "start": "0900", "end": "1500", "day": 5}, {"is_overnight": false,
+        "start": "0900", "end": "1500", "day": 6}], "hours_type": "REGULAR", "is_open_now":
+        false}], "transactions": []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:37 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_request_is_valid/creates_a_gym_member.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_request_is_valid/creates_a_gym_member.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-dc8nb; site=public_api_v3
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
-      Server:
-      - envoy
-      X-B3-Sampled:
-      - '0'
       X-Zipkin-Id:
-      - 6311ceb48007003c
+      - 5e58e5ac9f7d9e6e
       Ratelimit-Dailylimit:
       - '5000'
       Ratelimit-Remaining:
-      - '4811'
+      - '4798'
+      Server:
+      - envoy
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-8fpx7; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       X-Extlb:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-126-17-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:32 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-bur17526-BUR
+      - cache-lax10638-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,7 +84,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:32 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -109,36 +109,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gx6zl; site=public_api_v3
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
       Ratelimit-Remaining:
-      - '4810'
+      - '4797'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
       X-Zipkin-Id:
-      - 1fc956b9229b7535
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
-      X-B3-Sampled:
-      - '0'
-      Server:
-      - envoy
-      Ratelimit-Dailylimit:
-      - '5000'
+      - 224fe6a537ea61aa
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-185-39-uswest2bprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-185-39-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:32 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-lax10647-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -169,7 +169,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:32 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -194,20 +194,20 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
+      X-Zipkin-Id:
+      - 380df0b1084923d1
       Ratelimit-Dailylimit:
       - '5000'
+      Ratelimit-Remaining:
+      - '4796'
       X-B3-Sampled:
       - '0'
-      Ratelimit-Remaining:
-      - '4809'
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - c18e9cfe63c50df8
       Server:
       - envoy
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-wdbvd; site=public_api_v3
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
@@ -219,11 +219,11 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:32 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-bur17528-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -254,5 +254,5 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:32 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_request_is_valid/returns_status_code_201_created.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_request_is_valid/returns_status_code_201_created.yml
@@ -24,36 +24,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-dc8nb; site=public_api_v3
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      Server:
-      - envoy
       X-B3-Sampled:
       - '0'
-      X-Zipkin-Id:
-      - 6311ceb48007003c
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-wgl7j; site=public_api_v3
+      Server:
+      - envoy
       Ratelimit-Dailylimit:
       - '5000'
       Ratelimit-Remaining:
-      - '4811'
+      - '4795'
+      X-Zipkin-Id:
+      - 93eec56ee1e641fb
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       X-Extlb:
-      - 10-69-130-205-uswest2bprod
+      - 10-69-184-36-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:32 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-bur17526-BUR
+      - cache-lax10634-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -84,7 +84,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:32 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -109,36 +109,36 @@ http_interactions:
       - keep-alive
       Content-Type:
       - application/json
-      Ratelimit-Remaining:
-      - '4810'
-      Ratelimit-Resettime:
-      - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - 1fc956b9229b7535
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-fs2pm; site=public_api_v3
       X-B3-Sampled:
       - '0'
       Server:
       - envoy
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2df7g; site=public_api_v3
       Ratelimit-Dailylimit:
       - '5000'
+      Ratelimit-Remaining:
+      - '4794'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Zipkin-Id:
+      - 74f0615776d5af45
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-105-191-uswest2aprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:33 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-bur17532-BUR
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -169,7 +169,7 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:33 GMT
 - request:
     method: get
     uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
@@ -196,34 +196,34 @@ http_interactions:
       - application/json
       Ratelimit-Dailylimit:
       - '5000'
-      X-B3-Sampled:
-      - '0'
       Ratelimit-Remaining:
-      - '4809'
+      - '4793'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-vvc5d; site=public_api_v3
       Ratelimit-Resettime:
       - '2021-10-04T00:00:00+00:00'
-      X-Zipkin-Id:
-      - c18e9cfe63c50df8
       Server:
       - envoy
-      X-Routing-Service:
-      - routing-main--uswest2-7b96896cd8-wdbvd; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - d598f5dedef2d4df
       X-Cloudmap:
       - routing_uswest2
       X-Proxied:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-152-12-uswest2bprod
       X-Extlb:
-      - 10-69-113-185-uswest2aprod
+      - 10-69-152-12-uswest2bprod
       Cache-Control:
       - max-age=0, no-store, private, no-transform
       Accept-Ranges:
       - bytes
       Date:
-      - Sun, 03 Oct 2021 04:46:23 GMT
+      - Sun, 03 Oct 2021 04:46:33 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-lax10663-LGB
+      - cache-lax10654-LGB
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -254,5 +254,5 @@ http_interactions:
         "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
         "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
         []}'
-  recorded_at: Sun, 03 Oct 2021 04:46:23 GMT
+  recorded_at: Sun, 03 Oct 2021 04:46:33 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_gym_name_is_not_provided/returns_an_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_gym_name_is_not_provided/returns_an_error_message.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2df7g; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Remaining:
+      - '4790'
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - '09d156f7603db8df'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-105-191-uswest2aprod
+      X-Extlb:
+      - 10-69-105-191-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10649-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_gym_name_is_not_provided/returns_status_code_422_unprocessable_entity.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_gym_name_is_not_provided/returns_status_code_422_unprocessable_entity.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      X-Zipkin-Id:
+      - 6e572a7fb7710f7c
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4789'
+      X-B3-Sampled:
+      - '0'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-173-40-uswest2bprod
+      X-Extlb:
+      - 10-69-173-40-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10743-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_yelp_gym_id_is_not_provided/returns_an_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_yelp_gym_id_is_not_provided/returns_an_error_message.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4788'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      Server:
+      - envoy
+      X-Zipkin-Id:
+      - e13a231bc08c4a46
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-8fpx7; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-126-17-uswest2aprod
+      X-Extlb:
+      - 10-69-126-17-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10723-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_yelp_gym_id_is_not_provided/returns_status_code_422_unprocessable_entity.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_the_yelp_gym_id_is_not_provided/returns_status_code_422_unprocessable_entity.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      X-B3-Sampled:
+      - '0'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2brz6; site=public_api_v3
+      X-Zipkin-Id:
+      - 1010229b1f3f1a78
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4787'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-69-73-uswest2aprod
+      X-Extlb:
+      - 10-69-69-73-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:35 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-bur17571-BUR
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_user_does_not_exist/returns_an_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_user_does_not_exist/returns_an_error_message.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 04e0e9cc2c818c49
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-2j5zt; site=public_api_v3
+      Ratelimit-Remaining:
+      - '4792'
+      Ratelimit-Dailylimit:
+      - '5000'
+      Server:
+      - envoy
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-69-73-uswest2aprod
+      X-Extlb:
+      - 10-69-69-73-uswest2aprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:33 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sna10743-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_user_does_not_exist/returns_status_code_404_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/Users_GymMemberships_API/POST_/api/v1/users/_user_id/gym_memberships/when_the_user_does_not_exist/returns_status_code_404_not_found.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yelp.com/v3/businesses/gHmS3WIjRRhSWG4OdCQYLA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - DONT_SHARE_MY_SECRET_KEY
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - envoy
+      Ratelimit-Dailylimit:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4791'
+      Ratelimit-Resettime:
+      - '2021-10-04T00:00:00+00:00'
+      X-Routing-Service:
+      - routing-main--uswest2-7b96896cd8-gq6gs; site=public_api_v3
+      X-B3-Sampled:
+      - '0'
+      X-Zipkin-Id:
+      - 3ae66ecb316eb38d
+      X-Cloudmap:
+      - routing_uswest2
+      X-Proxied:
+      - 10-69-152-12-uswest2bprod
+      X-Extlb:
+      - 10-69-152-12-uswest2bprod
+      Cache-Control:
+      - max-age=0, no-store, private, no-transform
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Sun, 03 Oct 2021 04:46:34 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lax10662-LGB
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id": "gHmS3WIjRRhSWG4OdCQYLA", "alias": "quest-fitness-kennebunk-2",
+        "name": "Quest Fitness", "image_url": "https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg",
+        "is_claimed": true, "is_closed": false, "url": "https://www.yelp.com/biz/quest-fitness-kennebunk-2?adjust_creative=awGBNkM_j8pKscZth2VNGA&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=awGBNkM_j8pKscZth2VNGA",
+        "phone": "+12074673800", "display_phone": "(207) 467-3800", "review_count":
+        4, "categories": [{"alias": "healthtrainers", "title": "Trainers"}, {"alias":
+        "taichi", "title": "Tai Chi"}, {"alias": "yoga", "title": "Yoga"}], "rating":
+        5.0, "location": {"address1": "2 Livewell Dr", "address2": null, "address3":
+        null, "city": "Kennebunk", "zip_code": "04043", "country": "US", "state":
+        "ME", "display_address": ["2 Livewell Dr", "Kennebunk, ME 04043"], "cross_streets":
+        ""}, "coordinates": {"latitude": 43.393861, "longitude": -70.527933}, "photos":
+        ["https://s3-media4.fl.yelpcdn.com/bphoto/FJhv4yFveUoNyK5aJaDcqA/o.jpg", "https://s3-media1.fl.yelpcdn.com/bphoto/k-1eHyAz3uoOfM1lIcYx-A/o.jpg",
+        "https://s3-media4.fl.yelpcdn.com/bphoto/mZBPXGxNmvq4z6ZkzA36ow/o.jpg"], "hours":
+        [{"open": [{"is_overnight": false, "start": "0500", "end": "2030", "day":
+        0}, {"is_overnight": false, "start": "0500", "end": "2030", "day": 1}, {"is_overnight":
+        false, "start": "0500", "end": "2030", "day": 2}, {"is_overnight": false,
+        "start": "0500", "end": "2030", "day": 3}, {"is_overnight": false, "start":
+        "0500", "end": "1900", "day": 4}, {"is_overnight": false, "start": "0700",
+        "end": "1800", "day": 5}, {"is_overnight": false, "start": "0700", "end":
+        "1800", "day": 6}], "hours_type": "REGULAR", "is_open_now": false}], "transactions":
+        []}'
+  recorded_at: Sun, 03 Oct 2021 04:46:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -42,25 +42,27 @@ RSpec.describe Event, type: :model do
   end
 
   describe 'class methods' do
-    describe '::upcoming_invited_events and ::upcoming_past_events' do
+    describe '::upcoming_events and ::past_events' do
       let!(:user1) { user_with_gym_membership }
       let!(:user2) { user_with_gym_membership }
       let!(:gym_id) { user1.gym_memberships.first.id }
 
-      context 'when there are upcoming events' do
-        let!(:past_event) { create(:event, date_time: DateTime.yesterday, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_1) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_2) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_3) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
+      context 'when there are upcoming and past events' do
+        let!(:past_event_1) { create(:event, date_time: DateTime.yesterday - 1, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:past_event_2) { create(:event, date_time: DateTime.yesterday - 2, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_1) { create(:event, date_time: DateTime.tomorrow + 1, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_2) { create(:event, date_time: DateTime.tomorrow + 2, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_3) { create(:event, date_time: DateTime.tomorrow + 3, user_id: user2.id, gym_membership_id: gym_id) }
 
-        it 'returns the upcoming events' do
+        it 'returns the upcoming events in ascending order' do
           expect(Event.upcoming_events.first).to eq upcoming_event_1
           expect(Event.upcoming_events.second).to eq upcoming_event_2
           expect(Event.upcoming_events.third).to eq upcoming_event_3
         end
 
-        it 'returns the past events' do
-          expect(Event.past_events.first).to eq past_event
+        it 'returns the past events in descending order' do
+          expect(Event.past_events.first).to eq past_event_1
+          expect(Event.past_events.second).to eq past_event_2
         end
       end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Event, type: :model do
         expect(event.invited_name).to eq user2.full_name
       end
     end
+
+    describe '#gym_name and #yelp_gym_id' do
+      let!(:user) { user_with_gym_friend }
+      let(:gym_membership) { user.gym_memberships.first }
+      let(:event) { create(:event, user: user.followees.first, gym_membership: gym_membership) }
+
+      it 'can return the name and yelp_gym_id of the gym associated with the event' do
+        expect(event.gym_name).to eq gym_membership.gym_name
+        expect(event.yelp_gym_id).to eq gym_membership.yelp_gym_id
+      end
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -25,7 +25,25 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe 'delegations' do
+    describe '#gym_name and #yelp_gym_id' do
+      it { should delegate_method(:gym_name).to(:gym_membership) }
+      it { should delegate_method(:yelp_gym_id).to(:gym_membership) }
+    end
+  end
+
   describe 'instance methods' do
+    describe '#gym_name and #yelp_gym_id' do
+      let!(:user) { user_with_gym_friend }
+      let(:gym_membership) { user.gym_memberships.first }
+      let(:event) { create(:event, user: user.followees.first, gym_membership: gym_membership) }
+
+      it 'can return the name and yelp_gym_id of the gym associated with the event' do
+        expect(event.gym_name).to eq gym_membership.gym_name
+        expect(event.yelp_gym_id).to eq gym_membership.yelp_gym_id
+      end
+    end
+
     describe '#host_name and #invited_name' do
       let!(:user1) { user_with_gym_friend }
       let(:user2) { User.last }
@@ -37,17 +55,6 @@ RSpec.describe Event, type: :model do
       it 'can return the full names of the user hosting and the user invited to the event' do
         expect(event.host_name).to eq user1.full_name
         expect(event.invited_name).to eq user2.full_name
-      end
-    end
-
-    describe '#gym_name and #yelp_gym_id' do
-      let!(:user) { user_with_gym_friend }
-      let(:gym_membership) { user.gym_memberships.first }
-      let(:event) { create(:event, user: user.followees.first, gym_membership: gym_membership) }
-
-      it 'can return the name and yelp_gym_id of the gym associated with the event' do
-        expect(event.gym_name).to eq gym_membership.gym_name
-        expect(event.yelp_gym_id).to eq gym_membership.yelp_gym_id
       end
     end
   end

--- a/spec/models/gym_membership_spec.rb
+++ b/spec/models/gym_membership_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe GymMembership, type: :model do
       end
     end
   end
+
+  describe 'instance methods' do
+    describe '#address and #address_details', :vcr do
+      let!(:yelp_gym) { GymFacade.find_gym('gHmS3WIjRRhSWG4OdCQYLA') }
+      let(:user) { user_with_gym_membership(yelp_gym_id: yelp_gym.yelp_gym_id) }
+      let(:gym_membership) { user.gym_memberships.first }
+
+      it 'can return the address and address details of the gym membership' do
+        expect(gym_membership.address).to eq yelp_gym.address
+        expect(gym_membership.address_details).to eq yelp_gym.address_details
+      end
+    end
+  end
 end

--- a/spec/models/gym_membership_spec.rb
+++ b/spec/models/gym_membership_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe GymMembership, type: :model do
     end
   end
 
+  describe 'delegations' do
+    describe '#address and #address_details' do
+      it { should delegate_method(:address).to(:find_gym) }
+      it { should delegate_method(:address_details).to(:find_gym) }
+    end
+  end
+
   describe 'instance methods' do
     describe '#address and #address_details', :vcr do
       let!(:yelp_gym) { GymFacade.find_gym('gHmS3WIjRRhSWG4OdCQYLA') }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,18 +145,19 @@ RSpec.describe User, type: :model do
       let!(:user2) { user_with_gym_membership }
       let!(:gym_id) { user1.gym_memberships.first.id }
 
-      context 'when there are upcoming events' do
-        let!(:past_event) { create(:event, date_time: DateTime.yesterday, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_1) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_2) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
-        let!(:upcoming_event_3) { create(:event, date_time: DateTime.tomorrow, user_id: user2.id, gym_membership_id: gym_id) }
+      context 'when there are upcoming and past events' do
+        let!(:past_event_1) { create(:event, date_time: DateTime.yesterday - 1, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:past_event_2) { create(:event, date_time: DateTime.yesterday - 2, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_1) { create(:event, date_time: DateTime.tomorrow + 1, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_2) { create(:event, date_time: DateTime.tomorrow + 2, user_id: user2.id, gym_membership_id: gym_id) }
+        let!(:upcoming_event_3) { create(:event, date_time: DateTime.tomorrow + 3, user_id: user2.id, gym_membership_id: gym_id) }
 
-        it 'returns the upcoming events for the user' do
+        it 'returns the upcoming events for the user in ascending order' do
           expect(user1.all_upcoming_events).to eq [upcoming_event_1, upcoming_event_2, upcoming_event_3]
         end
 
-        it 'returns the past events for the user' do
-          expect(user1.all_past_events).to eq [past_event]
+        it 'returns the past events for the user in descending order' do
+          expect(user1.all_past_events).to eq [past_event_1, past_event_2]
         end
 
         it 'returns the upcoming events the user has been invited to' do

--- a/spec/requests/api/v1/users/events/index_request_spec.rb
+++ b/spec/requests/api/v1/users/events/index_request_spec.rb
@@ -15,8 +15,8 @@ describe 'Users::Events API', type: :request do
     let(:no_event_user_id) { user9.id }
     let(:bad_user_id) { User.last.id + 1 }
 
-    let!(:gym_id) { user1.gym_memberships.first.id }
-    let!(:past_event) { create(:event, date_time: DateTime.yesterday, user_id: user2.id, gym_membership_id: gym_id) }
+    let!(:gym_membership) { user1.gym_memberships.first }
+    let!(:past_event) { create(:event, date_time: DateTime.yesterday, user_id: user2.id, gym_membership: gym_membership) }
 
     context 'when the user has upcoming events they are hosting' do
       before { get "/api/v1/users/#{user_id}/events" }
@@ -29,9 +29,11 @@ describe 'Users::Events API', type: :request do
 
         meta = json_data.first[:meta]
 
-        expect(meta.size).to eq 2
+        expect(meta.size).to eq 4
         expect(meta[:friend_name]).to eq user2.full_name
         expect(meta[:friend_role]).to eq 'invited'
+        expect(meta[:gym_name]).to eq gym_membership.gym_name
+        expect(meta[:yelp_gym_id]).to eq gym_membership.yelp_gym_id
       end
 
       include_examples 'status code 200'
@@ -49,9 +51,11 @@ describe 'Users::Events API', type: :request do
 
         meta = json_data.first[:meta]
 
-        expect(meta.size).to eq 2
+        expect(meta.size).to eq 4
         expect(meta[:friend_name]).to eq user1.full_name
         expect(meta[:friend_role]).to eq 'host'
+        expect(meta[:gym_name]).to eq gym_membership.gym_name
+        expect(meta[:yelp_gym_id]).to eq gym_membership.yelp_gym_id
       end
 
       include_examples 'status code 200'
@@ -68,9 +72,11 @@ describe 'Users::Events API', type: :request do
 
         meta = json_data.first[:meta]
 
-        expect(meta.size).to eq 2
+        expect(meta.size).to eq 4
         expect(meta[:friend_name]).to eq user2.full_name
         expect(meta[:friend_role]).to eq 'invited'
+        expect(meta[:gym_name]).to eq gym_membership.gym_name
+        expect(meta[:yelp_gym_id]).to eq gym_membership.yelp_gym_id
       end
 
       include_examples 'status code 200'
@@ -87,9 +93,11 @@ describe 'Users::Events API', type: :request do
 
         meta = json_data.first[:meta]
 
-        expect(meta.size).to eq 2
+        expect(meta.size).to eq 4
         expect(meta[:friend_name]).to eq user1.full_name
         expect(meta[:friend_role]).to eq 'host'
+        expect(meta[:gym_name]).to eq gym_membership.gym_name
+        expect(meta[:yelp_gym_id]).to eq gym_membership.yelp_gym_id
       end
 
       include_examples 'status code 200'

--- a/spec/requests/api/v1/users/friendships/index_request_spec.rb
+++ b/spec/requests/api/v1/users/friendships/index_request_spec.rb
@@ -53,7 +53,7 @@ describe 'Users::Friendships API', type: :request do
       include_examples 'status code 200'
     end
 
-    context 'when yelp_gym_id is provided within query params' do
+    context "when yelp_gym_id and 'followers' relationship is provided within query params" do
       before { get "/api/v1/users/#{user_id}/friendships?yelp_gym_id=#{gym1}&relationship=followers" }
 
       it "returns the user's followers at that gym", :aggregate_failures do

--- a/spec/requests/api/v1/users/friendships/index_request_spec.rb
+++ b/spec/requests/api/v1/users/friendships/index_request_spec.rb
@@ -14,10 +14,10 @@ describe 'Users::Friendships API', type: :request do
     let(:no_friend_user_id) { user9.id }
     let(:bad_user_id) { User.last.id + 1 }
 
-    context 'when the user friendships records exists' do
+    context 'when the user is following other users' do
       before { get "/api/v1/users/#{user_id}/friendships" }
 
-      it 'returns the users friendships', :aggregate_failures do
+      it "returns the user's followees", :aggregate_failures do
         expect(json).not_to be_empty
         expect(json_data.size).to eq(5)
         expect(json_data.first[:id]).to eq(user2.id.to_s)
@@ -26,16 +26,41 @@ describe 'Users::Friendships API', type: :request do
       include_examples 'status code 200'
     end
 
-    context 'when I provide yelp_gym_id in query params' do
+    context 'when the user is followed by other users' do
+      before { get "/api/v1/users/#{user_id}/friendships?relationship=followers" }
+
+      it "returns the user's followers", :aggregate_failures do
+        expect(json).not_to be_empty
+        expect(json_data.size).to eq(1)
+        expect(json_data.first[:id]).to eq(user2.id.to_s)
+      end
+
+      include_examples 'status code 200'
+    end
+
+    context 'when yelp_gym_id is provided within query params' do
       before { get "/api/v1/users/#{user_id}/friendships?yelp_gym_id=#{gym1}" }
 
-      it 'returns the users friends at that gym', :aggregate_failures do
+      it "returns the user's followees at that gym", :aggregate_failures do
         expect(json).not_to be_empty
         expect(json_data.size).to eq(3)
 
         expect(json_data.first[:id]).to eq(user2.id.to_s)
         expect(json_data.second[:id]).to eq(user3.id.to_s)
         expect(json_data.third[:id]).to eq(user5.id.to_s)
+      end
+
+      include_examples 'status code 200'
+    end
+
+    context 'when yelp_gym_id is provided within query params' do
+      before { get "/api/v1/users/#{user_id}/friendships?yelp_gym_id=#{gym1}&relationship=followers" }
+
+      it "returns the user's followers at that gym", :aggregate_failures do
+        expect(json).not_to be_empty
+        expect(json_data.size).to eq(1)
+
+        expect(json_data.first[:id]).to eq(user2.id.to_s)
       end
 
       include_examples 'status code 200'
@@ -57,8 +82,15 @@ describe 'Users::Friendships API', type: :request do
       include_examples 'status code 404'
     end
 
-    context 'when the user has no friendships' do
+    context 'when the user is not following any users (has no followees)' do
       before { get "/api/v1/users/#{no_friend_user_id}/friendships" }
+
+      include_examples 'returns nil data'
+      include_examples 'status code 200'
+    end
+
+    context 'when the user has no followers' do
+      before { get "/api/v1/users/#{no_friend_user_id}/friendships?relationship=followers" }
 
       include_examples 'returns nil data'
       include_examples 'status code 200'

--- a/spec/requests/api/v1/users/gym_memberships/create_request_spec.rb
+++ b/spec/requests/api/v1/users/gym_memberships/create_request_spec.rb
@@ -7,9 +7,11 @@ require 'rails_helper'
 #
 # See spec/support/request_spec_helper.rb for #json and #json_data helpers.
 describe 'Users::GymMemberships API', type: :request do
-  describe 'POST /api/v1/users/:user_id/gym_memberships' do
-    let!(:user) { create(:user) }
-    let(:yelp_gym_id) { 'c2jzsndq8brvn9fbckeec2' }
+  describe 'POST /api/v1/users/:user_id/gym_memberships', :vcr do
+    let!(:yelp_gym) { GymFacade.find_gym('gHmS3WIjRRhSWG4OdCQYLA') }
+    let!(:user) { user_with_gym_membership(yelp_gym_id: yelp_gym.yelp_gym_id) }
+    let(:gym_membership) { user.gym_memberships.first }
+    let(:yelp_gym_id) { gym_membership.yelp_gym_id }
     let(:gym_name) { 'Planet Fitness' }
     let(:valid_attributes) do
       {
@@ -24,10 +26,12 @@ describe 'Users::GymMemberships API', type: :request do
 
       it 'creates a gym member', :aggregate_failures do
         expect(json).not_to be_empty
-        expect(json_data.size).to eq(3)
-        expect(json_data[:attributes][:user_id]).to eq(user.id)
-        expect(json_data[:attributes][:yelp_gym_id]).to eq(yelp_gym_id)
-        expect(json_data[:attributes][:gym_name]).to eq(gym_name)
+        expect(json_data.size).to eq 4
+        expect(json_data[:attributes][:user_id]).to eq user.id
+        expect(json_data[:attributes][:yelp_gym_id]).to eq yelp_gym_id
+        expect(json_data[:attributes][:gym_name]).to eq gym_name
+        expect(json_data[:meta][:address]).to eq yelp_gym.address
+        expect(json_data[:meta][:address_details]).to eq yelp_gym.address_details
       end
 
       include_examples 'status code 201'

--- a/spec/requests/api/v1/users/gym_memberships/index_request_spec.rb
+++ b/spec/requests/api/v1/users/gym_memberships/index_request_spec.rb
@@ -7,7 +7,7 @@ require 'rails_helper'
 #
 # See spec/support/request_spec_helper.rb for #json and #json_data helpers.
 describe 'Users::GymMemberhips API', type: :request do
-  describe 'GET /api/v1/users/:id/gym_memberships' do
+  describe 'GET /api/v1/users/:id/gym_memberships', :vcr do
     # See spec/factories/users.rb for #experienced_user test setup method
     experienced_user
     let(:user_id) { user1.id }
@@ -24,6 +24,10 @@ describe 'Users::GymMemberhips API', type: :request do
         expect(json_data.size).to eq(2)
         expect(json_data.first[:id]).to eq(gym_membership1_id.to_s)
         expect(json_data.second[:id]).to eq(gym_membership2_id.to_s)
+        expect(json_data.first[:meta][:address]).to eq GymFacade.find_gym(gym1).address
+        expect(json_data.first[:meta][:address_details]).to eq GymFacade.find_gym(gym1).address_details
+        expect(json_data.second[:meta][:address]).to eq GymFacade.find_gym(gym2).address
+        expect(json_data.second[:meta][:address_details]).to eq GymFacade.find_gym(gym2).address_details
       end
 
       include_examples 'status code 200'

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -8,15 +8,16 @@ describe 'EventSerializer', type: :serializer do
         let(:event_hash) { EventSerializer.new(event).serializable_hash }
         let(:event_data) { event_hash[:data] }
         let(:event_attributes) { event_data[:attributes] }
+        let(:event_meta) { event_data[:meta] }
 
         it 'formats the single event response for delivery', :aggregate_failures do
           expect(event_hash).to be_a Hash
-          expect(event_hash.size).to eq(1)
+          expect(event_hash.size).to eq 1
 
           expect(event_hash).to have_key(:data)
 
           expect(event_data).to be_a Hash
-          expect(event_data.size).to eq(4)
+          expect(event_data.size).to eq 4
 
           expect(event_data).to have_key(:id)
           expect(event_data[:id]).to be_a String
@@ -27,7 +28,7 @@ describe 'EventSerializer', type: :serializer do
 
           expect(event_data).to have_key(:attributes)
           expect(event_attributes).to be_a Hash
-          expect(event_attributes.size).to eq(4)
+          expect(event_attributes.size).to eq 4
 
           expect(event_attributes).to have_key(:user_id)
           expect(event_attributes[:user_id]).to be_an Integer
@@ -41,15 +42,15 @@ describe 'EventSerializer', type: :serializer do
           expect(event_attributes).to have_key(:activity)
           expect(event_attributes[:activity]).to be_a String
 
-          expect(event_data[:meta].size).to eq 4
-          expect(event_data[:meta]).to have_key(:friend_name)
-          expect(event_data[:meta]).to have_key(:friend_role)
-          expect(event_data[:meta]).to have_key(:gym_name)
-          expect(event_data[:meta]).to have_key(:yelp_gym_id)
-          expect(event_data[:meta][:friend_name]).to be_a String
-          expect(event_data[:meta][:friend_role]).to be_a String
-          expect(event_data[:meta][:gym_name]).to be_a String
-          expect(event_data[:meta][:yelp_gym_id]).to be_a String
+          expect(event_meta.size).to eq 4
+          expect(event_meta).to have_key(:friend_name)
+          expect(event_meta).to have_key(:friend_role)
+          expect(event_meta).to have_key(:gym_name)
+          expect(event_meta).to have_key(:yelp_gym_id)
+          expect(event_meta[:friend_name]).to be_a String
+          expect(event_meta[:friend_role]).to be_a String
+          expect(event_meta[:gym_name]).to be_a String
+          expect(event_meta[:yelp_gym_id]).to be_a String
         end
       end
 
@@ -58,7 +59,7 @@ describe 'EventSerializer', type: :serializer do
 
         it 'returns a hash with data as nil' do
           expect(empty_event).to be_a Hash
-          expect(empty_event.size).to eq(1)
+          expect(empty_event.size).to eq 1
 
           expect(empty_event).to have_key(:data)
           expect(empty_event[:data]).to be_nil

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -41,11 +41,15 @@ describe 'EventSerializer', type: :serializer do
           expect(event_attributes).to have_key(:activity)
           expect(event_attributes[:activity]).to be_a String
 
-          expect(event_data[:meta].size).to eq 2
+          expect(event_data[:meta].size).to eq 4
           expect(event_data[:meta]).to have_key(:friend_name)
           expect(event_data[:meta]).to have_key(:friend_role)
+          expect(event_data[:meta]).to have_key(:gym_name)
+          expect(event_data[:meta]).to have_key(:yelp_gym_id)
           expect(event_data[:meta][:friend_name]).to be_a String
           expect(event_data[:meta][:friend_role]).to be_a String
+          expect(event_data[:meta][:gym_name]).to be_a String
+          expect(event_data[:meta][:yelp_gym_id]).to be_a String
         end
       end
 

--- a/spec/serializers/gym_membership_serializer_spec.rb
+++ b/spec/serializers/gym_membership_serializer_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe 'GymMembershipSerializer', type: :serializer do
+  describe 'instance methods' do
+    describe '#serializable_hash' do
+      context 'when I provide a valid gym membership', :vcr do
+        let!(:yelp_gym) { GymFacade.find_gym('gHmS3WIjRRhSWG4OdCQYLA') }
+        let(:user) { user_with_gym_membership(yelp_gym_id: yelp_gym.yelp_gym_id) }
+        let(:gym_membership) { user.gym_memberships.first }
+        let(:gym_membership_hash) { GymMembershipSerializer.new(gym_membership).serializable_hash }
+        let(:gym_membership_data) { gym_membership_hash[:data] }
+        let(:gym_membership_attributes) { gym_membership_data[:attributes] }
+        let(:gym_membership_meta) { gym_membership_data[:meta] }
+
+        it 'formats the single gym membership response for delivery', :aggregate_failures do
+          expect(gym_membership_hash).to be_a Hash
+          expect(gym_membership_hash.size).to eq 1
+
+          expect(gym_membership_hash).to have_key(:data)
+
+          expect(gym_membership_data).to be_a Hash
+          expect(gym_membership_data.size).to eq 4
+
+          expect(gym_membership_data).to have_key(:id)
+          expect(gym_membership_data[:id]).to be_a String
+
+          expect(gym_membership_data).to have_key(:type)
+          expect(gym_membership_data[:type]).to be_a Symbol
+          expect(gym_membership_data[:type]).to eq(:gym_membership)
+
+          expect(gym_membership_data).to have_key(:attributes)
+          expect(gym_membership_attributes).to be_a Hash
+          expect(gym_membership_attributes.size).to eq 3
+
+          expect(gym_membership_attributes).to have_key(:user_id)
+          expect(gym_membership_attributes[:user_id]).to be_an Integer
+
+          expect(gym_membership_attributes).to have_key(:yelp_gym_id)
+          expect(gym_membership_attributes[:yelp_gym_id]).to be_a String
+
+          expect(gym_membership_attributes).to have_key(:gym_name)
+          expect(gym_membership_attributes[:gym_name]).to be_a String
+
+          expect(gym_membership_meta.size).to eq 2
+          expect(gym_membership_meta).to have_key(:address)
+          expect(gym_membership_meta).to have_key(:address_details)
+          expect(gym_membership_meta[:address]).to be_a String
+          expect(gym_membership_meta[:address_details]).to be_a Hash
+        end
+      end
+
+      context 'when I provide no valid event or events' do
+        subject(:empty_gym_membership) { GymMembershipSerializer.new(nil).serializable_hash }
+
+        it 'returns a hash with data as nil' do
+          expect(empty_gym_membership).to be_a Hash
+          expect(empty_gym_membership.size).to eq(1)
+
+          expect(empty_gym_membership).to have_key(:data)
+          expect(empty_gym_membership[:data]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Changes Implemented:
  - GET `/users/:id/friendships` [#80](https://github.com/tvaroglu/spot_me_frontend/issues/80)
      - Added ability to return followers of the current user, via option for new query param `?relationship=followers` within existing `FriendshipsController.index` action to return both user sets, so we can have `followers` and `followees` method calls that functions the same way from the current endpoint
  - GET `/users/:id/events`:
      - Added additional `meta` to `Events` endpoint (`gym_name: <gym_name>` and `yelp_gym_id: <yelp_gym_id>`) [#98](https://github.com/tvaroglu/spot_me_frontend/issues/98)
      - Reversed sort order `desc` to be `asc` in helper methods (`Event` model) [#100](https://github.com/tvaroglu/spot_me_frontend/issues/100)
  - GET `/users/:id/gym_memberships`:
      - Added additional `meta` to `GymMemberships` endpoint (`address: <address>` and `address_details: <address details>`) [#89](https://github.com/tvaroglu/spot_me_frontend/issues/89)

- Quality Control Checklist:

  - [x] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
  - [x] 100% SimpleCov test coverage (if below, please clarify below)
  - [x] Last Commit passes CircleCI build


- Blockers (if applicable):

- Next Steps & Additional Notes:
  - Rerecord cassettes and update pending FE [PR](https://github.com/tvaroglu/spot_me_frontend/pull/109) for successful Circle build
